### PR TITLE
Use Correct DB List Launch Plan Method

### DIFF
--- a/pkg/manager/impl/launch_plan_manager.go
+++ b/pkg/manager/impl/launch_plan_manager.go
@@ -366,7 +366,7 @@ func (m *LaunchPlanManager) GetActiveLaunchPlan(ctx context.Context, request adm
 		InlineFilters: filters,
 	}
 
-	output, err := m.db.LaunchPlanRepo().ListLaunchPlanIdentifiers(ctx, listLaunchPlansInput)
+	output, err := m.db.LaunchPlanRepo().List(ctx, listLaunchPlansInput)
 
 	if err != nil {
 		logger.Debugf(ctx, "Failed to list active launch plan id for request [%+v] with err %v", request, err)


### PR DESCRIPTION
The GetActiveLaunchPlan implementation was incorrectly using the wrong database list method. This resulted in a mostly empty LaunchPlan model being returned which subsequently turned into a mostly empty LaunchPlan, including LaunchPlanSpec.