### PR TITLE
Switch jwt library

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -159,6 +159,14 @@
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:d64c893fc7d2c3d395f421b00d21f0adb8ceffc4d3c90299e732b3985ca16eb4"
+  name = "github.com/coreos/go-oidc"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "2be1c5b8a260760503f66dc0996e102b683b3ac3"
+  version = "v2.1.0"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -616,6 +624,17 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:bd9efe4e0b0f768302a1e2f0c22458149278de533e521206e5ddc71848c269a0"
+  name = "github.com/pquerna/cachecontrol"
+  packages = [
+    ".",
+    "cacheobject",
+  ]
+  pruneopts = "UT"
+  revision = "1555304b9b35fdd2b425bccf1a5613677705e7d0"
+
+[[projects]]
   digest = "1:e89f2cdede55684adbe44b5566f55838ad2aee1dff348d14b73ccf733607b671"
   name = "github.com/prometheus/client_golang"
   packages = [
@@ -771,9 +790,14 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:bbe51412d9915d64ffaa96b51d409e070665efc5194fcf145c4a27d4133107a4"
+  digest = "1:08644aeff6284192f9b529821257b83245e3a3a48e216074929629f62c3c5799"
   name = "golang.org/x/crypto"
-  packages = ["ssh/terminal"]
+  packages = [
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "pbkdf2",
+    "ssh/terminal",
+  ]
   pruneopts = "UT"
   revision = "9756ffdc24725223350eb3266ffb92590d28f278"
 
@@ -961,6 +985,18 @@
   version = "v0.9.1"
 
 [[projects]]
+  digest = "1:8c05919580be8a5be668709d7e5a69d5cd19b8ee9f23d62ce5b10d3457bf6a13"
+  name = "gopkg.in/square/go-jose.v2"
+  packages = [
+    ".",
+    "cipher",
+    "json",
+  ]
+  pruneopts = "UT"
+  revision = "730df5f748271903322feb182be83b43ebbbe27d"
+  version = "v2.3.1"
+
+[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
@@ -1144,6 +1180,7 @@
     "github.com/aws/aws-sdk-go/service/ses",
     "github.com/aws/aws-sdk-go/service/ses/sesiface",
     "github.com/benbjohnson/clock",
+    "github.com/coreos/go-oidc",
     "github.com/dgrijalva/jwt-go",
     "github.com/gogo/protobuf/proto",
     "github.com/golang/glog",
@@ -1178,6 +1215,7 @@
     "github.com/lyft/flytestdlib/config",
     "github.com/lyft/flytestdlib/config/viper",
     "github.com/lyft/flytestdlib/contextutils",
+    "github.com/lyft/flytestdlib/errors",
     "github.com/lyft/flytestdlib/logger",
     "github.com/lyft/flytestdlib/pbhash",
     "github.com/lyft/flytestdlib/profutils",

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -65,6 +65,8 @@ func newGRPCServer(ctx context.Context, cfg *config.ServerConfig, opts ...grpc.S
 	var chainedUnaryInterceptors grpc.UnaryServerInterceptor
 	if cfg.Security.UseAuth {
 		logger.Infof(ctx, "Creating gRPC server with authentication")
+		// TODO: See comment at other instantiation of Provider in this file. This is a duplicate for now until
+		//       we can clean up code and merge them.
 		oidcCtx := oidc.ClientContext(ctx, &http.Client{})
 		provider, err := oidc.NewProvider(oidcCtx, cfg.Security.Oauth.Claims.Issuer)
 		if err != nil {

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"github.com/coreos/go-oidc"
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/lyft/flyteadmin/pkg/auth"
@@ -60,13 +61,17 @@ func init() {
 
 // Creates a new gRPC Server with all the configuration
 func newGRPCServer(ctx context.Context, cfg *config.ServerConfig, opts ...grpc.ServerOption) (*grpc.Server, error) {
-
 	// Not yet implemented for streaming
 	var chainedUnaryInterceptors grpc.UnaryServerInterceptor
 	if cfg.Security.UseAuth {
 		logger.Infof(ctx, "Creating gRPC server with authentication")
+		oidcCtx := oidc.ClientContext(ctx, &http.Client{})
+		provider, err := oidc.NewProvider(oidcCtx, cfg.Security.Oauth.Claims.Issuer)
+		if err != nil {
+			return nil, err
+		}
 		chainedUnaryInterceptors = grpc_middleware.ChainUnaryServer(grpc_prometheus.UnaryServerInterceptor,
-			grpcauth.UnaryServerInterceptor(auth.GetAuthenticationInterceptor(cfg.Security.Oauth)),
+			grpcauth.UnaryServerInterceptor(auth.GetAuthenticationInterceptor(cfg.Security.Oauth, provider)),
 			auth.AuthenticationLoggingInterceptor,
 		)
 	} else {
@@ -127,14 +132,18 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, grpcAddress st
 	var gwmux *runtime.ServeMux
 	if cfg.Security.UseAuth {
 		// Configuration and setup
+		// TODO: Wrap OAuth2 config object, provider and anything else that might be needed into an AuthContext()
 		oauthConfig, err := auth.GetOauth2Config(cfg.Security.Oauth)
 		if err != nil {
 			logger.Errorf(ctx, "Could not load OAuth2 settings %s", err)
 			return nil, err
 		}
+		oidcCtx := oidc.ClientContext(ctx, &http.Client{})
+		provider, err := oidc.NewProvider(oidcCtx, cfg.Security.Oauth.Claims.Issuer)
+		if err != nil {
+			return nil, err
+		}
 
-		jwksUrl := cfg.Security.Oauth.JwksUrl
-		jwtVerifier := auth.JwtVerifier{Url: jwksUrl}
 		cookieManager, err := auth.NewCookieManager(ctx, cfg.Security.Oauth.CookieHashKeyFile, cfg.Security.Oauth.CookieBlockKeyFile)
 		if err != nil {
 			logger.Errorf(ctx, "Error creating cookie manager %s", err)
@@ -143,7 +152,7 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, grpcAddress st
 
 		// Add HTTP handlers for OAuth2 endpoints
 		mux.HandleFunc("/login_page", loginPage)
-		mux.HandleFunc("/login", auth.RefreshTokensIfExists(ctx, oauthConfig, cfg.Security.Oauth, jwtVerifier,
+		mux.HandleFunc("/login", auth.RefreshTokensIfExists(ctx, oauthConfig, cfg.Security.Oauth, provider,
 			cookieManager, auth.GetLoginHandler(ctx, oauthConfig)))
 		mux.HandleFunc("/callback", auth.GetCallbackHandler(ctx, oauthConfig, cfg.Security.Oauth, cookieManager))
 

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -2,84 +2,27 @@ package auth
 
 import (
 	"context"
-	"encoding/json"
-	"github.com/dgrijalva/jwt-go"
-	"github.com/lestrrat-go/jwx/jwk"
+	"github.com/coreos/go-oidc"
 	"github.com/lyft/flytestdlib/errors"
 	"github.com/lyft/flytestdlib/logger"
 	"golang.org/x/oauth2"
+	"strings"
 	"time"
 )
-
-const (
-	ErrJwtVerification errors.ErrorCode = "JWKS_FAILURE"
-)
-
-type JwtVerifier struct {
-	Url string
-}
-
-func (j *JwtVerifier) GetKey(token *jwt.Token) (interface{}, error) {
-	set, err := jwk.FetchHTTP(j.Url)
-	if err != nil {
-		return nil, err
-	}
-
-	keyID, ok := token.Header["kid"].(string)
-	if !ok {
-		return nil, errors.Errorf(ErrJwtVerification, "JWT header is missing a kid")
-	}
-
-	if key := set.LookupKeyID(keyID); len(key) == 1 {
-		return key[0].Materialize()
-	}
-
-	return nil, errors.Errorf(ErrJwtVerification, "unable to find key")
-}
 
 const (
 	ErrRefreshingToken errors.ErrorCode = "TOKEN_REFRESH_FAILURE"
 	ErrTokenExpired                     = "JWT_EXPIRED"
 	ErrJwtValidation                    = "JWT_VERIFICATION_FAILED"
-	ErrNilJwt                           = "NIL_JWT_ERROR"
-	ErrEmptySub                         = "SUB_EMPTY"
 )
 
-func getExpiration(claims jwt.MapClaims) *time.Time {
-	switch exp := claims["exp"].(type) {
-	case float64:
-		t := time.Unix(int64(exp), 0)
-		return &t
-	case json.Number:
-		v, _ := exp.Int64()
-		t := time.Unix(v, 0)
-		return &t
-	default:
-		return nil
-	}
-}
-
-// Refreshes a JWT.
-// NB: The input token and the output token are from two different libraries
-func GetRefreshedToken(ctx context.Context, oauth oauth2.Config, token jwt.Token, refreshToken string) (*oauth2.Token, error) {
+// Refresh a JWT
+func GetRefreshedToken(ctx context.Context, oauth oauth2.Config, accessToken, refreshToken string) (*oauth2.Token, error) {
 	logger.Debugf(ctx, "Attempting to refresh token")
-	claims := token.Claims.(jwt.MapClaims)
-	expiration := getExpiration(claims)
-	var originalToken oauth2.Token
-	if expiration == nil {
-		logger.Infof(ctx, "No expiration claim found")
-		originalToken = oauth2.Token{
-			AccessToken:  token.Raw,
-			RefreshToken: refreshToken,
-			Expiry:       time.Now().Add(-1 * time.Minute), // force expired by setting to the past
-		}
-	} else {
-		logger.Infof(ctx, "Refreshing access token with expiration %s", expiration)
-		originalToken = oauth2.Token{
-			AccessToken:  token.Raw,
-			RefreshToken: refreshToken,
-			Expiry:       *expiration,
-		}
+	originalToken := oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		Expiry:       time.Now().Add(-1 * time.Minute), // force expired by setting to the past
 	}
 
 	tokenSource := oauth.TokenSource(ctx, &originalToken)
@@ -92,39 +35,20 @@ func GetRefreshedToken(ctx context.Context, oauth oauth2.Config, token jwt.Token
 	return newToken, nil
 }
 
-func constructMapClaims(claims Claims) jwt.MapClaims {
-	// TODO: iterate
-	return jwt.MapClaims{
-		Aud: claims.Audience,
-		Iss: claims.Issuer,
-	}
-}
-
 func ParseAndValidate(ctx context.Context, options OAuthOptions, accessToken string,
-	keyFunc jwt.Keyfunc) (*jwt.Token, error) {
+	provider *oidc.Provider) (*oidc.IDToken, error) {
 
-	t, err := jwt.ParseWithClaims(accessToken, constructMapClaims(options.Claims), keyFunc)
+	var verifier = provider.Verifier(&oidc.Config{ClientID: options.Claims.Audience})
+
+	idToken, err := verifier.Verify(ctx, accessToken)
 	if err != nil {
 		logger.Debugf(ctx, "JWT parsing with claims failed %s", err)
 		flyteErr := errors.Wrapf(ErrJwtValidation, err, "jwt parse with claims failed")
-		if validationErr, ok := err.(*jwt.ValidationError); ok &&
-			validationErr.Errors == jwt.ValidationErrorExpired && t != nil {
-			return t, errors.Wrapf(ErrTokenExpired, flyteErr, "token is expired")
+		// TODO: Contribute an errors package to the go-oidc library for proper error handling
+		if strings.Contains(err.Error(), "token is expired") {
+			return idToken, errors.Wrapf(ErrTokenExpired, flyteErr, "token is expired")
 		}
-		return t, flyteErr
+		return idToken, flyteErr
 	}
-
-	return t, nil
-}
-
-func GetSubClaim(t *jwt.Token) (string, error) {
-	claims := t.Claims.(jwt.MapClaims)
-	if userEmail, ok := claims["sub"]; ok {
-		if userEmail.(string) != "" {
-			return userEmail.(string), nil
-		} else {
-			return "", errors.Errorf(ErrEmptySub, "Email not found in sub claim")
-		}
-	}
-	return "", errors.Errorf(ErrEmptySub, "No sub claim found")
+	return idToken, nil
 }

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -1,19 +1,64 @@
 package auth
 
 import (
-	"github.com/dgrijalva/jwt-go"
+	"context"
+	"fmt"
+	"github.com/coreos/go-oidc"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"strings"
 	"testing"
 )
 
-func TestParse(t *testing.T) {
-	jwtVerifier := JwtVerifier{
-		Url: "https://lyft.okta.com/oauth2/default/v1/keys",
+//func TestParse(t *testing.T) {
+//	jwtVerifier := JwtVerifier{
+//		Url: "https://lyft.okta.com/oauth2/default/v1/keys",
+//	}
+//	tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULndRZDFab0dxS3RJa3JGY3pmTlRkd1JnZmZZM0VDSjU1VmNPZDVjQmxEMncuQ05mcGRMVlNoem4wekdWZEp0T1kyL080TXcrM0pRc1BxSGFBSms5bkxQRT0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTY5MjgyODYzLCJleHAiOjE1NjkyODY0NjMsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib2ZmbGluZV9hY2Nlc3MiLCJvcGVuaWQiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.pVSnEBcATN6mE9PEa6Ht7Sd-EjzM3Cm6yxR-_pMWzo9DlmVFcV_T8WsNq2pdboblfuZXa-53a0aajrSXbWa-HkHOiE0g0RZaVBZdkp3Wtqj7Xnh9ROhvjLu8V42NcJBpvZlksjAepdoexaVHiIxcxM7lJf49ZiIrvE7L2ybuKYUE5iaZoM47jfizxUcRV-r_GriE0UtUoJRwioGKTm9bpPCA4odM7et42D1zd8bFs32so1cMJcSIHmvDIO5vZMYER29z1mZf-EKr9GrKSrUdjxDncnMspNt1BwwaI-hEf63csYOgxtmcgyTOjNpnIYgi0RB8G8UjDzn7qYyWbg4hhA"
+//	_, err := jwt.Parse(tokenStr, jwtVerifier.GetKey)
+//	assert.NotNil(t, err)
+//	validationErr, ok := err.(*jwt.ValidationError)
+//	assert.True(t, ok)
+//	assert.Equal(t, jwt.ValidationErrorExpired, validationErr.Errors)
+//}
+
+func TestOidc(t *testing.T) {
+	//tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULmRObmh1WTZPMm80QU1sOGNmYVRTWkNqQl9jNW1hYUNZUFZVdzRDZzJOTGcuWlFxMG5Tb0ZDTWl6RUlRUTNlL3gyaXoyY1EwNDdJemgrTDE5UTQ2Q3U4OD0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTcwNDAxNTU3LCJleHAiOjE1NzA0MDUxNTcsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib3BlbmlkIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.iTAwHhWZgdu-k6am8QH85Kt2l5duEiKuex5d2l0uAhppvVBKmyL1n2r55xxea5Q9AtQo_dFtUnceqmi6XVlksppZ__NAAG8v6vHzrUpin1G2XW4Ycv2_HMNSCAZCVQ_JCGIX9INxTb1K43sknZo0eMpEaf4Do24MtkJxQEZpCrPyt_qsMVxyRJBIsUcW3wzd8mMyvn5rX-EWIvDuaQYwrW2egCdw6I2IzWjZ923F9S-neHKkuf3E4fVnp8WUYoWs3BRR9LzZQPwDCES10sixLb7v6khopP4bW2L5yooccDp0Sdied08aFw63Uu4vzFRwIu_vEzEhSaDY7KOgccJjcA"
+	tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULnA1WUFlbzBodkhVODdBWGRqTVBDNXRrUG9fdHJBMnk3Z2hLQUMxQ1ktZWcucFNRZGJTR3RUK3hUV1Jza05ZaVd1L2FPSmEvUjd4OTRlbmpWb3dGL2c2QT0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTcwNDA2NjU4LCJleHAiOjE1NzA0MTAyNTgsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib2ZmbGluZV9hY2Nlc3MiLCJvcGVuaWQiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.VJtWuP4vZN50SMJ6VT4kU7u6YfthgTTSs4KPXj80KpXA5VLt9mXVmlGOoVEVUvJqmgZuh5xqHU0epJw7fgJCH7fBvqVaxmfWleaCJKeZ2lo9Ly5kE_RbxYGrhDu285FOmJzZd_p8zJ1KJRNy5zXbkMCOuRXSqFQol2INXcy7auyxFe4_pN6dMpsz5mbKghBsPPsyRmWBnpuWMIz8HmVZXy6CVh4ik2vSIFVdn9R6ulysSSxwgfZYNHi8NUn_Wbf4lk1VDKNlatgKpwDD4vRYzzE5vu0JdVNKt_TgKc7_VR4ZxUrf82lztHSNmAsnGg5hcCHGWKQKHtcprsI3OSYZDA"
+
+	myClient := &http.Client{}
+	ctx := oidc.ClientContext(context.Background(), myClient)
+
+	//keySet := oidc.NewRemoteKeySet(ctx, "https://lyft.okta.com/oauth2/default/v1/keys")
+
+	provider, err := oidc.NewProvider(ctx, "https://lyft.okta.com/oauth2/default")
+	if err != nil {
+		panic(err)
 	}
-	tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULndRZDFab0dxS3RJa3JGY3pmTlRkd1JnZmZZM0VDSjU1VmNPZDVjQmxEMncuQ05mcGRMVlNoem4wekdWZEp0T1kyL080TXcrM0pRc1BxSGFBSms5bkxQRT0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTY5MjgyODYzLCJleHAiOjE1NjkyODY0NjMsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib2ZmbGluZV9hY2Nlc3MiLCJvcGVuaWQiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.pVSnEBcATN6mE9PEa6Ht7Sd-EjzM3Cm6yxR-_pMWzo9DlmVFcV_T8WsNq2pdboblfuZXa-53a0aajrSXbWa-HkHOiE0g0RZaVBZdkp3Wtqj7Xnh9ROhvjLu8V42NcJBpvZlksjAepdoexaVHiIxcxM7lJf49ZiIrvE7L2ybuKYUE5iaZoM47jfizxUcRV-r_GriE0UtUoJRwioGKTm9bpPCA4odM7et42D1zd8bFs32so1cMJcSIHmvDIO5vZMYER29z1mZf-EKr9GrKSrUdjxDncnMspNt1BwwaI-hEf63csYOgxtmcgyTOjNpnIYgi0RB8G8UjDzn7qYyWbg4hhA"
-	_, err := jwt.Parse(tokenStr, jwtVerifier.GetKey)
-	assert.NotNil(t, err)
-	validationErr, ok := err.(*jwt.ValidationError)
-	assert.True(t, ok)
-	assert.Equal(t, jwt.ValidationErrorExpired, validationErr.Errors)
+	var verifier = provider.Verifier(&oidc.Config{ClientID: "api://default"})
+
+	x, err := verifier.Verify(context.Background(), tokenStr)
+	assert.NoError(t, err)
+	if err != nil {
+		fmt.Printf("%v\n", err)
+	}
+}
+
+// Until the go-oidc library uses typed errors, we are left to check expiration with a string match.
+// This test ensures that.
+func TestExpiredToken(t *testing.T) {
+	expiredToken := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULmRObmh1WTZPMm80QU1sOGNmYVRTWkNqQl9jNW1hYUNZUFZVdzRDZzJOTGcuWlFxMG5Tb0ZDTWl6RUlRUTNlL3gyaXoyY1EwNDdJemgrTDE5UTQ2Q3U4OD0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTcwNDAxNTU3LCJleHAiOjE1NzA0MDUxNTcsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib3BlbmlkIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.iTAwHhWZgdu-k6am8QH85Kt2l5duEiKuex5d2l0uAhppvVBKmyL1n2r55xxea5Q9AtQo_dFtUnceqmi6XVlksppZ__NAAG8v6vHzrUpin1G2XW4Ycv2_HMNSCAZCVQ_JCGIX9INxTb1K43sknZo0eMpEaf4Do24MtkJxQEZpCrPyt_qsMVxyRJBIsUcW3wzd8mMyvn5rX-EWIvDuaQYwrW2egCdw6I2IzWjZ923F9S-neHKkuf3E4fVnp8WUYoWs3BRR9LzZQPwDCES10sixLb7v6khopP4bW2L5yooccDp0Sdied08aFw63Uu4vzFRwIu_vEzEhSaDY7KOgccJjcA"
+
+	myClient := &http.Client{}
+	ctx := oidc.ClientContext(context.Background(), myClient)
+	provider, err := oidc.NewProvider(ctx, "https://lyft.okta.com/oauth2/default")
+	if err != nil {
+		panic(err)
+	}
+	var verifier = provider.Verifier(&oidc.Config{ClientID: "api://default"})
+
+	x, err := verifier.Verify(context.Background(), expiredToken)
+	assert.Nil(t, x)
+	assert.Error(t, err)
+	assert.True(t, strings.Contains(err.Error(), "token is expired"))
 }

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -2,47 +2,12 @@ package auth
 
 import (
 	"context"
-	"fmt"
 	"github.com/coreos/go-oidc"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"strings"
 	"testing"
 )
-
-//func TestParse(t *testing.T) {
-//	jwtVerifier := JwtVerifier{
-//		Url: "https://lyft.okta.com/oauth2/default/v1/keys",
-//	}
-//	tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULndRZDFab0dxS3RJa3JGY3pmTlRkd1JnZmZZM0VDSjU1VmNPZDVjQmxEMncuQ05mcGRMVlNoem4wekdWZEp0T1kyL080TXcrM0pRc1BxSGFBSms5bkxQRT0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTY5MjgyODYzLCJleHAiOjE1NjkyODY0NjMsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib2ZmbGluZV9hY2Nlc3MiLCJvcGVuaWQiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.pVSnEBcATN6mE9PEa6Ht7Sd-EjzM3Cm6yxR-_pMWzo9DlmVFcV_T8WsNq2pdboblfuZXa-53a0aajrSXbWa-HkHOiE0g0RZaVBZdkp3Wtqj7Xnh9ROhvjLu8V42NcJBpvZlksjAepdoexaVHiIxcxM7lJf49ZiIrvE7L2ybuKYUE5iaZoM47jfizxUcRV-r_GriE0UtUoJRwioGKTm9bpPCA4odM7et42D1zd8bFs32so1cMJcSIHmvDIO5vZMYER29z1mZf-EKr9GrKSrUdjxDncnMspNt1BwwaI-hEf63csYOgxtmcgyTOjNpnIYgi0RB8G8UjDzn7qYyWbg4hhA"
-//	_, err := jwt.Parse(tokenStr, jwtVerifier.GetKey)
-//	assert.NotNil(t, err)
-//	validationErr, ok := err.(*jwt.ValidationError)
-//	assert.True(t, ok)
-//	assert.Equal(t, jwt.ValidationErrorExpired, validationErr.Errors)
-//}
-
-func TestOidc(t *testing.T) {
-	//tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULmRObmh1WTZPMm80QU1sOGNmYVRTWkNqQl9jNW1hYUNZUFZVdzRDZzJOTGcuWlFxMG5Tb0ZDTWl6RUlRUTNlL3gyaXoyY1EwNDdJemgrTDE5UTQ2Q3U4OD0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTcwNDAxNTU3LCJleHAiOjE1NzA0MDUxNTcsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib3BlbmlkIiwib2ZmbGluZV9hY2Nlc3MiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.iTAwHhWZgdu-k6am8QH85Kt2l5duEiKuex5d2l0uAhppvVBKmyL1n2r55xxea5Q9AtQo_dFtUnceqmi6XVlksppZ__NAAG8v6vHzrUpin1G2XW4Ycv2_HMNSCAZCVQ_JCGIX9INxTb1K43sknZo0eMpEaf4Do24MtkJxQEZpCrPyt_qsMVxyRJBIsUcW3wzd8mMyvn5rX-EWIvDuaQYwrW2egCdw6I2IzWjZ923F9S-neHKkuf3E4fVnp8WUYoWs3BRR9LzZQPwDCES10sixLb7v6khopP4bW2L5yooccDp0Sdied08aFw63Uu4vzFRwIu_vEzEhSaDY7KOgccJjcA"
-	tokenStr := "eyJraWQiOiItY2FQXzgyX1o0cVVDMnUtWkRPS2pPYVVIa2RkaWN3YUJOMGJjMTZIb3ZFIiwiYWxnIjoiUlMyNTYifQ.eyJ2ZXIiOjEsImp0aSI6IkFULnA1WUFlbzBodkhVODdBWGRqTVBDNXRrUG9fdHJBMnk3Z2hLQUMxQ1ktZWcucFNRZGJTR3RUK3hUV1Jza05ZaVd1L2FPSmEvUjd4OTRlbmpWb3dGL2c2QT0iLCJpc3MiOiJodHRwczovL2x5ZnQub2t0YS5jb20vb2F1dGgyL2RlZmF1bHQiLCJhdWQiOiJhcGk6Ly9kZWZhdWx0IiwiaWF0IjoxNTcwNDA2NjU4LCJleHAiOjE1NzA0MTAyNTgsImNpZCI6IjBvYWJzNTJna3VYNFZ6WXRKMXQ3IiwidWlkIjoiMDB1MXAyMjB2NmRtc0N3Y28xdDciLCJzY3AiOlsib2ZmbGluZV9hY2Nlc3MiLCJvcGVuaWQiXSwic3ViIjoieXRvbmdAbHlmdC5jb20ifQ.VJtWuP4vZN50SMJ6VT4kU7u6YfthgTTSs4KPXj80KpXA5VLt9mXVmlGOoVEVUvJqmgZuh5xqHU0epJw7fgJCH7fBvqVaxmfWleaCJKeZ2lo9Ly5kE_RbxYGrhDu285FOmJzZd_p8zJ1KJRNy5zXbkMCOuRXSqFQol2INXcy7auyxFe4_pN6dMpsz5mbKghBsPPsyRmWBnpuWMIz8HmVZXy6CVh4ik2vSIFVdn9R6ulysSSxwgfZYNHi8NUn_Wbf4lk1VDKNlatgKpwDD4vRYzzE5vu0JdVNKt_TgKc7_VR4ZxUrf82lztHSNmAsnGg5hcCHGWKQKHtcprsI3OSYZDA"
-
-	myClient := &http.Client{}
-	ctx := oidc.ClientContext(context.Background(), myClient)
-
-	//keySet := oidc.NewRemoteKeySet(ctx, "https://lyft.okta.com/oauth2/default/v1/keys")
-
-	provider, err := oidc.NewProvider(ctx, "https://lyft.okta.com/oauth2/default")
-	if err != nil {
-		panic(err)
-	}
-	var verifier = provider.Verifier(&oidc.Config{ClientID: "api://default"})
-
-	x, err := verifier.Verify(context.Background(), tokenStr)
-	assert.NoError(t, err)
-	if err != nil {
-		fmt.Printf("%v\n", err)
-	}
-}
 
 // Until the go-oidc library uses typed errors, we are left to check expiration with a string match.
 // This test ensures that.


### PR DESCRIPTION
Switched out the jwt-go library for the go-oidc library, which is also capable of handling jwt verification, and is even better because it caches jwks key sets.