### PR TITLE
Support postgres extra options [gcp]

### DIFF
--- a/flyteadmin_config.yaml
+++ b/flyteadmin_config.yaml
@@ -22,8 +22,8 @@ database:
   port: 5432
   username: postgres
   host: localhost
-  dbname: flyte
-  password: postgres
+  dbname: postgres
+  options: "sslmode=disable"
 scheduler:
   eventScheduler:
     scheme: local

--- a/flyteadmin_config.yaml
+++ b/flyteadmin_config.yaml
@@ -22,8 +22,8 @@ database:
   port: 5432
   username: postgres
   host: localhost
-  dbname: postgres
-  options: "sslmode=disable"
+  dbname: flyte
+  password: postgres
 scheduler:
   eventScheduler:
     scheme: local

--- a/pkg/repositories/config/postgres.go
+++ b/pkg/repositories/config/postgres.go
@@ -53,8 +53,8 @@ func (p *PostgresConfigProvider) GetArgs() string {
 		return fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=disable",
 			p.config.Host, p.config.Port, p.config.DbName, p.config.User)
 	}
-	return fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s",
-		p.config.Host, p.config.Port, p.config.DbName, p.config.User, p.config.Password)
+	return fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s %s",
+		p.config.Host, p.config.Port, p.config.DbName, p.config.User, p.config.Password, p.config.ExtraOptions)
 }
 
 func (p *PostgresConfigProvider) WithDebugModeEnabled() {


### PR DESCRIPTION
Right now it is enforced to use sslmode when flyte admin is connecting to postgres and password provided. The PR make it possible to connect to postgres when disabling sslmode.