### PR TITLE
Support postgres extra options [gcp]

### DIFF
--- a/pkg/repositories/config/postgres.go
+++ b/pkg/repositories/config/postgres.go
@@ -53,8 +53,8 @@ func (p *PostgresConfigProvider) GetArgs() string {
 		return fmt.Sprintf("host=%s port=%d dbname=%s user=%s sslmode=disable",
 			p.config.Host, p.config.Port, p.config.DbName, p.config.User)
 	}
-	return fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s",
-		p.config.Host, p.config.Port, p.config.DbName, p.config.User, p.config.Password)
+	return fmt.Sprintf("host=%s port=%d dbname=%s user=%s password=%s %s",
+		p.config.Host, p.config.Port, p.config.DbName, p.config.User, p.config.Password, p.config.ExtraOptions)
 }
 
 func (p *PostgresConfigProvider) WithDebugModeEnabled() {

--- a/pkg/repositories/config/postgres_test.go
+++ b/pkg/repositories/config/postgres_test.go
@@ -19,3 +19,16 @@ func TestConstructGormArgs(t *testing.T) {
 
 	assert.Equal(t, "host=localhost port=5432 dbname=postgres user=postgres sslmode=disable", postgresConfigProvider.GetArgs())
 }
+
+func TestConstructGormArgsWithPassword(t *testing.T) {
+	postgresConfigProvider := NewPostgresConfigProvider(DbConfig{
+		Host:         "localhost",
+		Port:         5432,
+		DbName:       "postgres",
+		User:         "postgres",
+		Password:     "pass",
+		ExtraOptions: "sslmode=enable",
+	}, mockScope.NewTestScope())
+
+	assert.Equal(t, "host=localhost port=5432 dbname=postgres user=postgres password=pass sslmode=enable", postgresConfigProvider.GetArgs())
+}

--- a/pkg/repositories/config/postgres_test.go
+++ b/pkg/repositories/config/postgres_test.go
@@ -32,3 +32,15 @@ func TestConstructGormArgsWithPassword(t *testing.T) {
 
 	assert.Equal(t, "host=localhost port=5432 dbname=postgres user=postgres password=pass sslmode=enable", postgresConfigProvider.GetArgs())
 }
+
+func TestConstructGormArgsWithPasswordNoExtra(t *testing.T) {
+	postgresConfigProvider := NewPostgresConfigProvider(DbConfig{
+		Host:     "localhost",
+		Port:     5432,
+		DbName:   "postgres",
+		User:     "postgres",
+		Password: "pass",
+	}, mockScope.NewTestScope())
+
+	assert.Equal(t, "host=localhost port=5432 dbname=postgres user=postgres password=pass ", postgresConfigProvider.GetArgs())
+}


### PR DESCRIPTION
Right now it is enforced to use sslmode when flyte admin is connecting to postgres and password provided. The PR make it possible to connect to postgres when disabling sslmode.