### PR TITLE
Fix invalid filter function error message

### DIFF
--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -80,6 +80,7 @@ var executionIdentifierFields = map[string]bool{
 	"name":    true,
 }
 
+const unrecognizedFilterFunction = "unrecognized filter function: %s"
 const unsupportedFilterExpression = "unsupported filter expression: %s"
 const invalidSingleValueFilter = "invalid single value filter expression: %s"
 const invalidRepeatedValueFilter = "invalid repeated value filter expression: %s"
@@ -105,6 +106,11 @@ func getFilterExpressionName(expression FilterExpression) string {
 	default:
 		return ""
 	}
+}
+
+func GetUnrecognizedFilterFunctionErr(function string) error {
+	return errors.NewFlyteAdminErrorf(codes.InvalidArgument, unrecognizedFilterFunction,
+		function)
 }
 
 func GetUnsupportedFilterExpressionErr(expression FilterExpression) error {
@@ -252,7 +258,7 @@ func NewInlineFilter(entity Entity, function string, field string, value interfa
 	expression, ok := filterNameMappings[function]
 	if !ok {
 		logger.Debugf(context.Background(), "can't create filter for unrecognized function: %s", function)
-		return nil, GetUnsupportedFilterExpressionErr(expression)
+		return nil, GetUnrecognizedFilterFunctionErr(function)
 	}
 	if isSingleValueFilter := singleValueFilters[expression]; isSingleValueFilter {
 		return NewSingleValueFilter(entity, expression, field, value)

--- a/pkg/manager/impl/util/filters_test.go
+++ b/pkg/manager/impl/util/filters_test.go
@@ -81,6 +81,11 @@ func TestParseFilters(t *testing.T) {
 	actualFilterExpression, _ = taskFilters[2].GetGormQueryExpr()
 	assert.Equal(t, "bar in (?)", actualFilterExpression.Query)
 	assert.Equal(t, []interface{}{"4", "5", "6"}, actualFilterExpression.Args)
+
+	filterExpression = "invalid_operator(foo,bar)"
+	taskFilters, err = ParseFilters(filterExpression, common.Task)
+	assert.Error(t, err)
+	assert.EqualError(t, err, "unrecognized filter function: invalid_operator")
 }
 
 func TestGetEqualityFilter(t *testing.T) {

--- a/pkg/manager/impl/util/filters_test.go
+++ b/pkg/manager/impl/util/filters_test.go
@@ -82,10 +82,10 @@ func TestParseFilters(t *testing.T) {
 	assert.Equal(t, "bar in (?)", actualFilterExpression.Query)
 	assert.Equal(t, []interface{}{"4", "5", "6"}, actualFilterExpression.Args)
 
-	filterExpression = "invalid_operator(foo,bar)"
+	filterExpression = "invalid_function(foo,bar)"
 	taskFilters, err = ParseFilters(filterExpression, common.Task)
 	assert.Error(t, err)
-	assert.EqualError(t, err, "unrecognized filter function: invalid_operator")
+	assert.EqualError(t, err, "unrecognized filter function: invalid_function")
 }
 
 func TestGetEqualityFilter(t *testing.T) {

--- a/pkg/manager/impl/util/filters_test.go
+++ b/pkg/manager/impl/util/filters_test.go
@@ -83,7 +83,7 @@ func TestParseFilters(t *testing.T) {
 	assert.Equal(t, []interface{}{"4", "5", "6"}, actualFilterExpression.Args)
 
 	filterExpression = "invalid_function(foo,bar)"
-	taskFilters, err = ParseFilters(filterExpression, common.Task)
+	_, err = ParseFilters(filterExpression, common.Task)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "unrecognized filter function: invalid_function")
 }


### PR DESCRIPTION
Currently, if you use an invalid filter function, e.g. `neq(phase,RUNNING)`, the error message (via the GRPC gateway) is -

```
{"error":"unsupported filter expression: contains","code":3,"message":"unsupported filter expression: contains"}
```

This is confusing as it names a function that isn't actually the one that's invalid. This happens because the message takes a FilterExpression value, but when the function is invalid, the filter expression value is its zero-value, `0`, which happens to correspond to the value for `Contains`.

This PR fixes this by clarifying the message and passes the function string directly.