### PR TITLE
Metadata url and base url as items in the auth context

### DIFF
--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -133,6 +133,7 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, authContext in
 		if authContext.GetUserInfoURL() != nil && authContext.GetUserInfoURL().String() != "" {
 			mux.HandleFunc("/me", auth.GetMeEndpointHandler(ctx, authContext))
 		}
+		// The metadata endpoint is an RFC-defined constant, but we need a leading / for the handler to pattern match correctly.
 		mux.HandleFunc(fmt.Sprintf("/%s", auth.MetadataEndpoint), auth.GetMetadataEndpointRedirectHandler(ctx, authContext))
 
 		// This option translates HTTP authorization data (cookies) into a gRPC metadata field

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -3,6 +3,7 @@ package entrypoints
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
@@ -132,7 +133,7 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, authContext in
 		if authContext.GetUserInfoURL() != nil && authContext.GetUserInfoURL().String() != "" {
 			mux.HandleFunc("/me", auth.GetMeEndpointHandler(ctx, authContext))
 		}
-		mux.HandleFunc(auth.MetadataEndpoint, auth.GetMetadataEndpointRedirectHandler(ctx, authContext))
+		mux.HandleFunc(fmt.Sprintf("/%s", auth.MetadataEndpoint), auth.GetMetadataEndpointRedirectHandler(ctx, authContext))
 
 		// This option translates HTTP authorization data (cookies) into a gRPC metadata field
 		gwmuxOptions = append(gwmuxOptions, runtime.WithMetadata(auth.GetHTTPRequestCookieToMetadataHandler(authContext)))

--- a/pkg/auth/config/config.go
+++ b/pkg/auth/config/config.go
@@ -11,6 +11,7 @@ type OAuthOptions struct {
 
 	// This should be the base url of the authorization server that you are trying to hit. With Okta for instance, it
 	// will look something like https://company.okta.com/oauth2/abcdef123456789/
+	// TODO: Convert all the URLs in this config to the config.URL type
 	BaseURL string `json:"baseUrl"`
 
 	// These two config elements currently need the entire path, including the already specified baseUrl

--- a/pkg/auth/constants.go
+++ b/pkg/auth/constants.go
@@ -10,7 +10,7 @@ const DefaultAuthorizationHeader = "authorization"
 const BearerScheme = "Bearer"
 
 // https://tools.ietf.org/html/rfc8414
-const MetadataEndpoint = "/.well-known/oauth-authorization-server"
+const MetadataEndpoint = ".well-known/oauth-authorization-server"
 
 // IDP specific
 const OfflineAccessType = "offline_access"

--- a/pkg/auth/constants.go
+++ b/pkg/auth/constants.go
@@ -10,6 +10,7 @@ const DefaultAuthorizationHeader = "authorization"
 const BearerScheme = "Bearer"
 
 // https://tools.ietf.org/html/rfc8414
+// This should be defined without a leading slash. If there is one, the url library's ResolveReference will make it a root path
 const MetadataEndpoint = ".well-known/oauth-authorization-server"
 
 // IDP specific

--- a/pkg/auth/handlers.go
+++ b/pkg/auth/handlers.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"path"
 
 	"github.com/gorilla/handlers"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
@@ -248,8 +247,8 @@ func GetMeEndpointHandler(ctx context.Context, authCtx interfaces.Authentication
 // See https://tools.ietf.org/html/rfc8414 for more information.
 func GetMetadataEndpointRedirectHandler(ctx context.Context, authCtx interfaces.AuthenticationContext) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		uri := path.Join(authCtx.Options().BaseURL, MetadataEndpoint)
-		http.Redirect(writer, request, uri, http.StatusSeeOther)
+		metadataURL := authCtx.GetBaseURL().ResolveReference(authCtx.GetMetadataURL())
+		http.Redirect(writer, request, metadataURL.String(), http.StatusSeeOther)
 	}
 }
 

--- a/pkg/auth/handlers_test.go
+++ b/pkg/auth/handlers_test.go
@@ -69,6 +69,6 @@ func TestGetMetadataEndpointRedirectHandler(t *testing.T) {
 	assert.NoError(t, err)
 	w := httptest.NewRecorder()
 	handler(w, req)
-	assert.Equal(t, 303, w.Code)
+	assert.Equal(t, http.StatusSeeOther, w.Code)
 	assert.Equal(t, "http://www.google.com/.well-known/oauth-authorization-server", w.Header()["Location"][0])
 }

--- a/pkg/auth/handlers_test.go
+++ b/pkg/auth/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 
 	"github.com/lyft/flyteadmin/pkg/auth/interfaces/mocks"
@@ -52,4 +53,22 @@ func TestGetHttpRequestCookieToMetadataHandler(t *testing.T) {
 	assert.NoError(t, err)
 	req.AddCookie(&jwtCookie)
 	assert.Equal(t, "Bearer a.b.c", handler(ctx, req)["authorization"][0])
+}
+
+func TestGetMetadataEndpointRedirectHandler(t *testing.T) {
+	ctx := context.Background()
+	baseURL, err := url.Parse("http://www.google.com")
+	assert.NoError(t, err)
+	metadataPath, err := url.Parse(MetadataEndpoint)
+	assert.NoError(t, err)
+	mockAuthCtx := mocks.AuthenticationContext{}
+	mockAuthCtx.On("GetBaseURL").Return(baseURL)
+	mockAuthCtx.On("GetMetadataURL").Return(metadataPath)
+	handler := GetMetadataEndpointRedirectHandler(ctx, &mockAuthCtx)
+	req, err := http.NewRequest("GET", "/xyz", nil)
+	assert.NoError(t, err)
+	w := httptest.NewRecorder()
+	handler(w, req)
+	assert.Equal(t, 303, w.Code)
+	assert.Equal(t, "http://www.google.com/.well-known/oauth-authorization-server", w.Header()["Location"][0])
 }

--- a/pkg/auth/interfaces/context.go
+++ b/pkg/auth/interfaces/context.go
@@ -20,5 +20,7 @@ type AuthenticationContext interface {
 	CookieManager() CookieHandler
 	Options() config.OAuthOptions
 	GetUserInfoURL() *url.URL
+	GetBaseURL() *url.URL
+	GetMetadataURL() *url.URL
 	GetHTTPClient() *http.Client
 }

--- a/pkg/auth/interfaces/mocks/authentication_context.go
+++ b/pkg/auth/interfaces/mocks/authentication_context.go
@@ -45,6 +45,22 @@ func (_m *AuthenticationContext) CookieManager() interfaces.CookieHandler {
 	return r0
 }
 
+// GetBaseURL provides a mock function with given fields:
+func (_m *AuthenticationContext) GetBaseURL() *url.URL {
+	ret := _m.Called()
+
+	var r0 *url.URL
+	if rf, ok := ret.Get(0).(func() *url.URL); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*url.URL)
+		}
+	}
+
+	return r0
+}
+
 // GetHTTPClient provides a mock function with given fields:
 func (_m *AuthenticationContext) GetHTTPClient() *http.Client {
 	ret := _m.Called()
@@ -55,6 +71,22 @@ func (_m *AuthenticationContext) GetHTTPClient() *http.Client {
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*http.Client)
+		}
+	}
+
+	return r0
+}
+
+// GetMetadataURL provides a mock function with given fields:
+func (_m *AuthenticationContext) GetMetadataURL() *url.URL {
+	ret := _m.Called()
+
+	var r0 *url.URL
+	if rf, ok := ret.Get(0).(func() *url.URL); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*url.URL)
 		}
 	}
 


### PR DESCRIPTION
Was incorrectly using `path.Join` in order to join URL paths.  This would've failed on windows, and also the redirect for the metadata and user info endpoints ended up being like `http:/blah.okta.com/...` instead of having the correct `//`.

Added a couple functions to the context interface to get these.
Added more todo's around config object to implement the actual use of the discovery endpoints. This will get rid of a lot of the URLs in the config.