### PR TITLE
add server reflection

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -921,7 +921,7 @@
   revision = "919d9bdd9fe6f1a5dd95ce5d5e4cdb8fd3c516d0"
 
 [[projects]]
-  digest = "1:0c0ea0f0ccec8a112245dd3ca0c3b304224ede9afd4b7a2b482a7b48471ef894"
+  digest = "1:ca45e0a856db4fdac5d23492fed11be07e5c86c62a26ed0bbd63f89fbb23b6a4"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -954,6 +954,8 @@
     "metadata",
     "naming",
     "peer",
+    "reflection",
+    "reflection/grpc_reflection_v1alpha",
     "resolver",
     "serviceconfig",
     "stats",
@@ -1239,6 +1241,7 @@
     "google.golang.org/grpc/credentials",
     "google.golang.org/grpc/grpclog",
     "google.golang.org/grpc/metadata",
+    "google.golang.org/grpc/reflection",
     "google.golang.org/grpc/status",
     "gopkg.in/gormigrate.v1",
     "k8s.io/apimachinery/pkg/api/errors",

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -33,6 +33,7 @@ import (
 	"github.com/lyft/flytestdlib/contextutils"
 	"github.com/lyft/flytestdlib/promutils/labeled"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
 )
 
 // serveCmd represents the serve command
@@ -84,6 +85,7 @@ func newGRPCServer(ctx context.Context, cfg *config.ServerConfig, authContext in
 	grpcServer := grpc.NewServer(serverOpts...)
 	grpc_prometheus.Register(grpcServer)
 	flyteService.RegisterAdminServiceServer(grpcServer, adminservice.NewAdminServer(cfg.KubeConfig, cfg.Master))
+	reflection.Register(grpcServer)
 	return grpcServer, nil
 }
 

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -85,7 +85,9 @@ func newGRPCServer(ctx context.Context, cfg *config.ServerConfig, authContext in
 	grpcServer := grpc.NewServer(serverOpts...)
 	grpc_prometheus.Register(grpcServer)
 	flyteService.RegisterAdminServiceServer(grpcServer, adminservice.NewAdminServer(cfg.KubeConfig, cfg.Master))
-	reflection.Register(grpcServer)
+	if cfg.GrpcServerReflection {
+		reflection.Register(grpcServer)
+	}
 	return grpcServer, nil
 }
 

--- a/flyteadmin_config.yaml
+++ b/flyteadmin_config.yaml
@@ -5,6 +5,7 @@
 server:
   httpPort: 8088
   grpcPort: 8089
+  grpcServerReflection: true
   security:
     secure: false
     ssl:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,11 +12,12 @@ const SectionKey = "server"
 //go:generate pflags ServerConfig --default-var=defaultServerConfig
 
 type ServerConfig struct {
-	HTTPPort   int                   `json:"httpPort" pflag:",On which http port to serve admin"`
-	GrpcPort   int                   `json:"grpcPort" pflag:",On which grpc port to serve admin"`
-	KubeConfig string                `json:"kube-config" pflag:",Path to kubernetes client config file."`
-	Master     string                `json:"master" pflag:",The address of the Kubernetes API server."`
-	Security   ServerSecurityOptions `json:"security"`
+	HTTPPort             int                   `json:"httpPort" pflag:",On which http port to serve admin"`
+	GrpcPort             int                   `json:"grpcPort" pflag:",On which grpc port to serve admin"`
+	GrpcServerReflection bool                  `json:"grpcServerReflection" pflag:",Enable GRPC Server Reflection"`
+	KubeConfig           string                `json:"kube-config" pflag:",Path to kubernetes client config file."`
+	Master               string                `json:"master" pflag:",The address of the Kubernetes API server."`
+	Security             ServerSecurityOptions `json:"security"`
 }
 
 type ServerSecurityOptions struct {

--- a/pkg/config/serverconfig_flags.go
+++ b/pkg/config/serverconfig_flags.go
@@ -43,6 +43,7 @@ func (cfg ServerConfig) GetPFlagSet(prefix string) *pflag.FlagSet {
 	cmdFlags := pflag.NewFlagSet("ServerConfig", pflag.ExitOnError)
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "httpPort"), defaultServerConfig.HTTPPort, "On which http port to serve admin")
 	cmdFlags.Int(fmt.Sprintf("%v%v", prefix, "grpcPort"), defaultServerConfig.GrpcPort, "On which grpc port to serve admin")
+	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "grpcServerReflection"), defaultServerConfig.GrpcServerReflection, "Enable GRPC Server Reflection")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "kube-config"), defaultServerConfig.KubeConfig, "Path to kubernetes client config file.")
 	cmdFlags.String(fmt.Sprintf("%v%v", prefix, "master"), defaultServerConfig.Master, "The address of the Kubernetes API server.")
 	cmdFlags.Bool(fmt.Sprintf("%v%v", prefix, "security.secure"), defaultServerConfig.Security.Secure, "")

--- a/pkg/config/serverconfig_flags_test.go
+++ b/pkg/config/serverconfig_flags_test.go
@@ -143,6 +143,28 @@ func TestServerConfig_SetFlags(t *testing.T) {
 			}
 		})
 	})
+	t.Run("Test_grpcServerReflection", func(t *testing.T) {
+		t.Run("DefaultValue", func(t *testing.T) {
+			// Test that default value is set properly
+			if vBool, err := cmdFlags.GetBool("grpcServerReflection"); err == nil {
+				assert.Equal(t, bool(defaultServerConfig.GrpcServerReflection), vBool)
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+
+		t.Run("Override", func(t *testing.T) {
+			testValue := "1"
+
+			cmdFlags.Set("grpcServerReflection", testValue)
+			if vBool, err := cmdFlags.GetBool("grpcServerReflection"); err == nil {
+				testDecodeJson_ServerConfig(t, fmt.Sprintf("%v", vBool), &actual.GrpcServerReflection)
+
+			} else {
+				assert.FailNow(t, err.Error())
+			}
+		})
+	})
 	t.Run("Test_kube-config", func(t *testing.T) {
 		t.Run("DefaultValue", func(t *testing.T) {
 			// Test that default value is set properly


### PR DESCRIPTION
The same as https://github.com/lyft/datacatalog/pull/19

With [server reflection](https://github.com/grpc/grpc-go/blob/master/Documentation/server-reflection-tutorial.md), it would be easier to interact with GRPC service using e.g. `grpcurl`.

flyteadmin does come with HTTP endpoint as well, but interacting with GRPC directly makes it more handy.