### PR TITLE
Fix broken redirects for separate domains

### DIFF
--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -116,7 +116,7 @@ func NewRedirectCookie(ctx context.Context, redirectURL string) *http.Cookie {
 
 	return &http.Cookie{
 		Name:     redirectURLCookieName,
-		Value:    urlObj.EscapedPath(),
+		Value:    urlObj.String(),
 		SameSite: http.SameSiteStrictMode,
 		HttpOnly: true,
 	}

--- a/pkg/auth/cookie.go
+++ b/pkg/auth/cookie.go
@@ -117,7 +117,7 @@ func NewRedirectCookie(ctx context.Context, redirectURL string) *http.Cookie {
 	return &http.Cookie{
 		Name:     redirectURLCookieName,
 		Value:    urlObj.String(),
-		SameSite: http.SameSiteStrictMode,
+		SameSite: http.SameSiteLaxMode,
 		HttpOnly: true,
 	}
 }

--- a/pkg/auth/cookie_test.go
+++ b/pkg/auth/cookie_test.go
@@ -90,10 +90,19 @@ func TestVerifyCsrfCookie(t *testing.T) {
 }
 
 func TestNewRedirectCookie(t *testing.T) {
-	ctx := context.Background()
-	cookie := NewRedirectCookie(ctx, "/console")
-	assert.NotNil(t, cookie)
-	assert.Equal(t, "/console", cookie.Value)
+	t.Run("test local path", func(t *testing.T) {
+		ctx := context.Background()
+		cookie := NewRedirectCookie(ctx, "/console")
+		assert.NotNil(t, cookie)
+		assert.Equal(t, "/console", cookie.Value)
+	})
+
+	t.Run("test external domain", func(t *testing.T) {
+		ctx := context.Background()
+		cookie := NewRedirectCookie(ctx, "http://www.example.com/postLogin")
+		assert.NotNil(t, cookie)
+		assert.Equal(t, "http://www.example.com/postLogin", cookie.Value)
+	})
 }
 
 func TestGetAuthFlowEndRedirect(t *testing.T) {

--- a/pkg/auth/cookie_test.go
+++ b/pkg/auth/cookie_test.go
@@ -103,6 +103,13 @@ func TestNewRedirectCookie(t *testing.T) {
 		assert.NotNil(t, cookie)
 		assert.Equal(t, "http://www.example.com/postLogin", cookie.Value)
 	})
+
+	t.Run("uses same-site lax policy", func(t *testing.T) {
+		ctx := context.Background()
+		cookie := NewRedirectCookie(ctx, "http://www.example.com/postLogin")
+		assert.NotNil(t, cookie)
+		assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+	})
 }
 
 func TestGetAuthFlowEndRedirect(t *testing.T) {


### PR DESCRIPTION
`URL.EscapedPath()` only returns the path portion of a URL. For example, in `http://example.com/path`, the returned value would be `/path`. This has the effect of throwing away the domain on the `redirect_url` query parameter and making it impossible to redirect to a different domain.

This PR changes the code to use `URL.String()`, which will reconstruct the entire URL. It calls `EscapedPath()` under the hood to construct the path portion of the URL. It also updates the `SameSite` mode to be `http.SameSiteLax` so that the cookie will be preserved when redirecting back from Okta.