### PR TITLE
Add auth enforcement config options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ linux_compile:
 
 .PHONY: server
 server:
-	go run cmd/main.go --logtostderr --server.kube-config ~/.kube/config  --config ~/flyteadmin_config.yaml serve
+	go run cmd/main.go --logtostderr --server.kube-config ~/.kube/config  --config flyteadmin_config.yaml serve
 
 .PHONY: migrate
 migrate:

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ linux_compile:
 
 .PHONY: server
 server:
-	go run cmd/main.go --logtostderr --server.kube-config ~/.kube/config  --config flyteadmin_config.yaml serve
+	go run cmd/main.go --logtostderr --server.kube-config ~/.kube/config  --config ~/flyteadmin_config.yaml serve
 
 .PHONY: migrate
 migrate:

--- a/cmd/entrypoints/serve.go
+++ b/cmd/entrypoints/serve.go
@@ -146,6 +146,10 @@ func newHTTPServer(ctx context.Context, cfg *config.ServerConfig, authContext in
 
 		// This option translates HTTP authorization data (cookies) into a gRPC metadata field
 		gwmuxOptions = append(gwmuxOptions, runtime.WithMetadata(auth.GetHTTPRequestCookieToMetadataHandler(authContext)))
+
+		// In an attempt to be able to selectively enforce whether or not authentication is required, we're going to tag
+		// the requests that come from the HTTP gateway. See the enforceHttp/Grpc options for more information.
+		gwmuxOptions = append(gwmuxOptions, runtime.WithMetadata(auth.GetHTTPMetadataTaggingHandler(authContext)))
 	}
 
 	// Create the grpc-gateway server with the options specified

--- a/pkg/auth/config/config.go
+++ b/pkg/auth/config/config.go
@@ -56,8 +56,8 @@ type OAuthOptions struct {
 	// dimension that made the most sense to cut by at time of writing is HTTP vs gRPC as the web UI mainly used HTTP
 	// and the backend used mostly gRPC.  Cutting by individual endpoints is another option but it possibly falls more
 	// into the realm of authorization rather than authentication.
-	EnforceHttp bool `json:"enforceHttp"`
-	EnforceGrpc bool `json:"enforceGrpc"`
+	DisableForHTTP bool `json:"disableForHttp"`
+	DisableForGrpc bool `json:"disableForGrpc"`
 }
 
 type Claims struct {

--- a/pkg/auth/config/config.go
+++ b/pkg/auth/config/config.go
@@ -51,6 +51,13 @@ type OAuthOptions struct {
 	// name. Instead, there is a gRPC interceptor, GetAuthenticationCustomMetadataInterceptor, that will translate
 	// incoming metadata headers with this config setting's name, into that standard header
 	GrpcAuthorizationHeader string `json:"grpcAuthorizationHeader"`
+
+	// To help ease migration, it was helpful to be able to only selectively enforce authentication.  The
+	// dimension that made the most sense to cut by at time of writing is HTTP vs gRPC as the web UI mainly used HTTP
+	// and the backend used mostly gRPC.  Cutting by individual endpoints is another option but it possibly falls more
+	// into the realm of authorization rather than authentication.
+	EnforceHttp bool `json:"enforceHttp"`
+	EnforceGrpc bool `json:"enforceGrpc"`
 }
 
 type Claims struct {

--- a/pkg/auth/handlers.go
+++ b/pkg/auth/handlers.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"net/http"
 
 	"github.com/gorilla/handlers"
-	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/lyft/flyteadmin/pkg/auth/interfaces"
 	"github.com/lyft/flytestdlib/contextutils"
 	"github.com/lyft/flytestdlib/errors"
@@ -150,38 +150,35 @@ func GetAuthenticationCustomMetadataInterceptor(authCtx interfaces.Authenticatio
 	}
 }
 
-// This function will only look for a token from the request metadata, verify it, and extract the user email if valid.
-// Unless there is an error, it will not return an unauthorized status. That is up to subsequent functions to decide,
-// based on configuration.  We don't want to require authentication for all endpoints.
+// This is the function that chooses to enforce or not enforce authentication. It will attempt to get the token
+// from the incoming context, validate it, and decide whether or not to let the request through.
 func GetAuthenticationInterceptor(authContext interfaces.AuthenticationContext) func(context.Context) (context.Context, error) {
 	return func(ctx context.Context) (context.Context, error) {
 		logger.Debugf(ctx, "Running authentication gRPC interceptor")
-		tokenStr, err := grpcauth.AuthFromMD(ctx, BearerScheme)
-		if err != nil {
-			logger.Debugf(ctx, "Could not retrieve bearer token from metadata %v", err)
-			return ctx, nil
+
+		fromHTTP := metautils.ExtractIncoming(ctx).Get("from_http")
+		isFromHTTP := fromHTTP == "true"
+
+		token, err := GetAndValidateTokenObjectFromContext(ctx, authContext.Claims(), authContext.OidcProvider())
+
+		// Only enforcement logic is present. The default case is to let things through.
+		if (isFromHTTP && authContext.Options().EnforceHttp) ||
+			(!isFromHTTP && authContext.Options().EnforceGrpc) {
+			if err != nil {
+				return ctx, status.Errorf(codes.Unauthenticated, "token parse error %s", err)
+			}
+			if token == nil {
+				return ctx, status.Errorf(codes.Unauthenticated, "Token was nil after parsing")
+			} else if token.Subject == "" {
+				return ctx, status.Errorf(codes.Unauthenticated, "no email or empty email found")
+			}
 		}
 
-		// Currently auth is optional...
-		if tokenStr == "" {
-			logger.Debugf(ctx, "Bearer token is empty, skipping parsing")
-			return ctx, nil
-		}
-
-		// ...however, if there _is_ a bearer token, but there are additional errors downstream, then we return an
-		// authentication error.
-		token, err := ParseAndValidate(ctx, authContext.Claims(), tokenStr, authContext.OidcProvider())
-		if err != nil {
-			return ctx, status.Errorf(codes.Unauthenticated, "could not parse token string into object: %s %s", tokenStr, err)
-		}
-		if token == nil {
-			return ctx, status.Errorf(codes.Unauthenticated, "Token was nil after parsing %s", tokenStr)
-		} else if token.Subject == "" {
-			return ctx, status.Errorf(codes.Unauthenticated, "no email or empty email found")
-		} else {
-			newCtx := WithUserEmail(context.WithValue(ctx, bearerTokenContextKey, tokenStr), token.Subject)
+		if token != nil {
+			newCtx := WithUserEmail(context.WithValue(ctx, bearerTokenContextKey, token), token.Subject)
 			return newCtx, nil
 		}
+		return ctx, nil
 	}
 }
 
@@ -205,6 +202,16 @@ func GetHTTPRequestCookieToMetadataHandler(authContext interfaces.Authentication
 		}
 		return metadata.MD{
 			DefaultAuthorizationHeader: []string{fmt.Sprintf("%s %s", BearerScheme, accessToken)},
+		}
+	}
+}
+
+// Intercepts the incoming HTTP requests and marks it as such so that the downstream code can use it to enforce auth.
+// See the enforceHTTP/Grpc options for more information.
+func GetHTTPMetadataTaggingHandler(authContext interfaces.AuthenticationContext) HTTPRequestToMetadataAnnotator {
+	return func(ctx context.Context, request *http.Request) metadata.MD {
+		return metadata.MD{
+			"from_http": []string{"true"},
 		}
 	}
 }

--- a/pkg/auth/handlers.go
+++ b/pkg/auth/handlers.go
@@ -21,6 +21,8 @@ import (
 
 const (
 	LoginRedirectURLParameter                  = "redirect_url"
+	FromHTTPKey                                = "from_http"
+	FromHTTPVal = "true"
 	bearerTokenContextKey     contextutils.Key = "bearer"
 	PrincipalContextKey       contextutils.Key = "principal"
 )
@@ -156,8 +158,8 @@ func GetAuthenticationInterceptor(authContext interfaces.AuthenticationContext) 
 	return func(ctx context.Context) (context.Context, error) {
 		logger.Debugf(ctx, "Running authentication gRPC interceptor")
 
-		fromHTTP := metautils.ExtractIncoming(ctx).Get("from_http")
-		isFromHTTP := fromHTTP == "true"
+		fromHTTP := metautils.ExtractIncoming(ctx).Get(FromHTTPKey)
+		isFromHTTP := fromHTTP == FromHTTPVal
 
 		token, err := GetAndValidateTokenObjectFromContext(ctx, authContext.Claims(), authContext.OidcProvider())
 
@@ -211,7 +213,7 @@ func GetHTTPRequestCookieToMetadataHandler(authContext interfaces.Authentication
 func GetHTTPMetadataTaggingHandler(authContext interfaces.AuthenticationContext) HTTPRequestToMetadataAnnotator {
 	return func(ctx context.Context, request *http.Request) metadata.MD {
 		return metadata.MD{
-			"from_http": []string{"true"},
+			FromHTTPKey: []string{FromHTTPVal},
 		}
 	}
 }

--- a/pkg/auth/handlers.go
+++ b/pkg/auth/handlers.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"net/http"
+
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 
 	"github.com/gorilla/handlers"
 	"github.com/lyft/flyteadmin/pkg/auth/interfaces"
@@ -22,7 +23,7 @@ import (
 const (
 	LoginRedirectURLParameter                  = "redirect_url"
 	FromHTTPKey                                = "from_http"
-	FromHTTPVal = "true"
+	FromHTTPVal                                = "true"
 	bearerTokenContextKey     contextutils.Key = "bearer"
 	PrincipalContextKey       contextutils.Key = "principal"
 )

--- a/pkg/auth/handlers_test.go
+++ b/pkg/auth/handlers_test.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"github.com/lyft/flyteadmin/pkg/auth/config"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -37,7 +38,7 @@ func TestGetLoginHandler(t *testing.T) {
 	assert.True(t, strings.Contains(w.Header().Get("Set-Cookie"), "flyte_csrf_state="))
 }
 
-func TestGetHttpRequestCookieToMetadataHandler(t *testing.T) {
+func TestGetHTTPRequestCookieToMetadataHandler(t *testing.T) {
 	ctx := context.Background()
 	// These were generated for unit testing only.
 	hashKeyEncoded := "wG4pE1ccdw/pHZ2ml8wrD5VJkOtLPmBpWbKHmezWXktGaFbRoAhXidWs8OpbA3y7N8vyZhz1B1E37+tShWC7gA" //nolint:goconst
@@ -52,6 +53,36 @@ func TestGetHttpRequestCookieToMetadataHandler(t *testing.T) {
 	jwtCookie, err := NewSecureCookie(accessTokenCookieName, "a.b.c", cookieManager.hashKey, cookieManager.blockKey)
 	assert.NoError(t, err)
 	req.AddCookie(&jwtCookie)
+	assert.Equal(t, "Bearer a.b.c", handler(ctx, req)["authorization"][0])
+}
+
+func TestGetHTTPMetadataTaggingHandler(t *testing.T) {
+	ctx := context.Background()
+	mockAuthCtx := mocks.AuthenticationContext{}
+	annotator := GetHTTPMetadataTaggingHandler(&mockAuthCtx)
+	request, err := http.NewRequest("GET", "/api", nil)
+	assert.NoError(t, err)
+	md := annotator(ctx, request)
+	assert.Equal(t, FromHTTPVal, md.Get(FromHTTPKey)[0])
+}
+
+func TestGetHTTPRequestCookieToMetadataHandler_CustomHeader(t *testing.T) {
+	ctx := context.Background()
+	// These were generated for unit testing only.
+	hashKeyEncoded := "wG4pE1ccdw/pHZ2ml8wrD5VJkOtLPmBpWbKHmezWXktGaFbRoAhXidWs8OpbA3y7N8vyZhz1B1E37+tShWC7gA" //nolint:goconst
+	blockKeyEncoded := "afyABVgGOvWJFxVyOvCWCupoTn6BkNl4SOHmahho16Q"                                           //nolint:goconst
+	cookieManager, err := NewCookieManager(ctx, hashKeyEncoded, blockKeyEncoded)
+	assert.NoError(t, err)
+	mockAuthCtx := mocks.AuthenticationContext{}
+	mockAuthCtx.On("CookieManager").Return(&cookieManager)
+	mockConfig := config.OAuthOptions{
+		HTTPAuthorizationHeader: "Custom-Header",
+	}
+	mockAuthCtx.On("Options").Return(mockConfig)
+	handler := GetHTTPRequestCookieToMetadataHandler(&mockAuthCtx)
+	req, err := http.NewRequest("GET", "/api/v1/projects", nil)
+	assert.NoError(t, err)
+	req.Header.Set("Custom-Header", "Bearer a.b.c")
 	assert.Equal(t, "Bearer a.b.c", handler(ctx, req)["authorization"][0])
 }
 

--- a/pkg/auth/handlers_test.go
+++ b/pkg/auth/handlers_test.go
@@ -2,11 +2,12 @@ package auth
 
 import (
 	"context"
-	"github.com/lyft/flyteadmin/pkg/auth/config"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+
+	"github.com/lyft/flyteadmin/pkg/auth/config"
 
 	"github.com/lyft/flyteadmin/pkg/auth/interfaces/mocks"
 	"github.com/stretchr/testify/assert"

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -2,14 +2,15 @@ package auth
 
 import (
 	"context"
+	"strings"
+	"time"
+
 	"github.com/coreos/go-oidc"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/lyft/flyteadmin/pkg/auth/config"
 	"github.com/lyft/flytestdlib/errors"
 	"github.com/lyft/flytestdlib/logger"
 	"golang.org/x/oauth2"
-	"strings"
-	"time"
 )
 
 const (

--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -2,14 +2,14 @@ package auth
 
 import (
 	"context"
-	"strings"
-	"time"
-
 	"github.com/coreos/go-oidc"
+	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
 	"github.com/lyft/flyteadmin/pkg/auth/config"
 	"github.com/lyft/flytestdlib/errors"
 	"github.com/lyft/flytestdlib/logger"
 	"golang.org/x/oauth2"
+	"strings"
+	"time"
 )
 
 const (
@@ -53,4 +53,22 @@ func ParseAndValidate(ctx context.Context, claims config.Claims, accessToken str
 		return idToken, flyteErr
 	}
 	return idToken, nil
+}
+
+// This function attempts to extract a token from the context, and will then call the validation function, passing up
+// any errors.
+func GetAndValidateTokenObjectFromContext(ctx context.Context, claims config.Claims,
+	provider *oidc.Provider) (*oidc.IDToken, error) {
+
+	tokenStr, err := grpcauth.AuthFromMD(ctx, BearerScheme)
+	if err != nil {
+		logger.Debugf(ctx, "Could not retrieve bearer token from metadata %v", err)
+		return nil, errors.Wrapf(ErrJwtValidation, err, "Could not retrieve bearer token from metadata")
+	}
+	if tokenStr == "" {
+		logger.Debugf(ctx, "Found Bearer scheme but token was blank")
+		return nil, errors.Errorf(ErrJwtValidation, "Bearer token is blank")
+	}
+
+	return ParseAndValidate(ctx, claims, tokenStr, provider)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,7 @@ var defaultServerConfig = &ServerConfig{
 	Security: ServerSecurityOptions{
 		Oauth: config2.OAuthOptions{
 			// Please see the comments in this struct's definition for more information
-			HTTPAuthorizationHeader: "placeholder",
+			HTTPAuthorizationHeader: "flyte-authorization",
 			GrpcAuthorizationHeader: "flyte-authorization",
 		},
 	},


### PR DESCRIPTION
This is the last bit of auth work on the Admin side of things.  Before this PR, if you present Admin with a bad or expired token, you will get a 401.  However, if you present no token whatsoever, Admin will let the request go through.  This PR begins enforcement.

To help with migration, we are incrementally going to require auth.  We were originally going to use the gRPC endpoint name to decide whether or not to enforce things, but ultimately it made more sense to divide up by protocol - HTTP vs gRPC. Since most programmatic (more problematic) traffic goes through gRPC and only Flyte Console uses HTTP, we can start by just doing HTTP.

In order to do this, the code tags incoming HTTP requests because the token validation code is further downstream.

Also
* Adding the bit of code to look for bearer tokens in http headers as well as cookies to support use-cases where we use the HTTP Admin API.  Note however, that Admin will be deployed with a custom config so that the header you should send is `Flyte-Authorization` not the default `Authorization`, so the complete header would look something like `Flyte-Authorization: Bearer j.w.t`
(CC @haoyuez )



