### PR TITLE
Implement get and delete for attributes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -453,7 +453,7 @@
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:b1ab65fa43650fb503aa710091eb9d13c6c5d7f0cf14684039827b457a1f2ac9"
+  digest = "1:9f01843d5ce98395a8af3da88dc6c67d169e0e94d253337026c423e2b18cdf4f"
   name = "github.com/lyft/flyteidl"
   packages = [
     "clients/go/admin",
@@ -466,9 +466,9 @@
     "gen/pb-go/flyteidl/service",
   ]
   pruneopts = "UT"
-  revision = "6deb3c002d84b2012f02cdecc32902f475deda83"
+  revision = "28c0dfb6608b70262aac9cb1ff83a750521ded8e"
   source = "https://github.com/lyft/flyteidl"
-  version = "v0.16.4"
+  version = "v0.16.5"
 
 [[projects]]
   digest = "1:938998e14bd5e42c54f3b640a41d869eb79029ad7c623fa47c604b8480c781fc"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -60,7 +60,7 @@
 [[override]]
   name = "github.com/lyft/flyteidl"
   source = "https://github.com/lyft/flyteidl"
-  version = "^0.16.x"
+  version = "^0.16.5"
 
 [[constraint]]
   name = "github.com/lyft/flytepropeller"

--- a/pkg/manager/impl/project_attributes_manager.go
+++ b/pkg/manager/impl/project_attributes_manager.go
@@ -36,6 +36,35 @@ func (m *ProjectAttributesManager) UpdateProjectAttributes(
 	return &admin.ProjectAttributesUpdateResponse{}, nil
 }
 
+func (m *ProjectAttributesManager) GetProjectAttributes(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+	*admin.ProjectAttributesGetResponse, error) {
+	if err := validation.ValidateProjectAttributesGetRequest(request); err != nil {
+		return nil, err
+	}
+	projectAttributesModel, err := m.db.ProjectAttributesRepo().Get(ctx, request.Project, request.ResourceType.String())
+	if err != nil {
+		return nil, err
+	}
+	projectAttributes, err := transformers.FromProjectAttributesModel(projectAttributesModel)
+	if err != nil {
+		return nil, err
+	}
+	return &admin.ProjectAttributesGetResponse{
+		Attributes: &projectAttributes,
+	}, nil
+}
+
+func (m *ProjectAttributesManager) DeleteProjectAttributes(ctx context.Context,
+	request admin.ProjectAttributesDeleteRequest) (*admin.ProjectAttributesDeleteResponse, error) {
+	if err := validation.ValidateProjectAttributesDeleteRequest(request); err != nil {
+		return nil, err
+	}
+	if err := m.db.ProjectAttributesRepo().Delete(ctx, request.Project, request.ResourceType.String()); err != nil {
+		return nil, err
+	}
+	return &admin.ProjectAttributesDeleteResponse{}, nil
+}
+
 func NewProjectAttributesManager(db repositories.RepositoryInterface) interfaces.ProjectAttributesInterface {
 	return &ProjectAttributesManager{
 		db: db,

--- a/pkg/manager/impl/project_domain_attributes_manager.go
+++ b/pkg/manager/impl/project_domain_attributes_manager.go
@@ -39,6 +39,38 @@ func (m *ProjectDomainAttributesManager) UpdateProjectDomainAttributes(
 	return &admin.ProjectDomainAttributesUpdateResponse{}, nil
 }
 
+func (m *ProjectDomainAttributesManager) GetProjectDomainAttributes(
+	ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+	*admin.ProjectDomainAttributesGetResponse, error) {
+	if err := validation.ValidateProjectDomainAttributesGetRequest(request); err != nil {
+		return nil, err
+	}
+	projectAttributesModel, err := m.db.ProjectDomainAttributesRepo().Get(
+		ctx, request.Project, request.Domain, request.ResourceType.String())
+	if err != nil {
+		return nil, err
+	}
+	projectAttributes, err := transformers.FromProjectDomainAttributesModel(projectAttributesModel)
+	if err != nil {
+		return nil, err
+	}
+	return &admin.ProjectDomainAttributesGetResponse{
+		Attributes: &projectAttributes,
+	}, nil
+}
+
+func (m *ProjectDomainAttributesManager) DeleteProjectDomainAttributes(ctx context.Context,
+	request admin.ProjectDomainAttributesDeleteRequest) (*admin.ProjectDomainAttributesDeleteResponse, error) {
+	if err := validation.ValidateProjectDomainAttributesDeleteRequest(request); err != nil {
+		return nil, err
+	}
+	if err := m.db.ProjectDomainAttributesRepo().Delete(
+		ctx, request.Project, request.Domain, request.ResourceType.String()); err != nil {
+		return nil, err
+	}
+	return &admin.ProjectDomainAttributesDeleteResponse{}, nil
+}
+
 func NewProjectDomainAttributesManager(
 	db repositories.RepositoryInterface) interfaces.ProjectDomainAttributesInterface {
 	return &ProjectDomainAttributesManager{

--- a/pkg/manager/impl/validation/attributes_validator.go
+++ b/pkg/manager/impl/validation/attributes_validator.go
@@ -38,6 +38,22 @@ func ValidateProjectAttributesUpdateRequest(request admin.ProjectAttributesUpdat
 	return validateMatchingAttributes(request.Attributes.MatchingAttributes, request.Attributes.Project)
 }
 
+func ValidateProjectAttributesGetRequest(request admin.ProjectAttributesGetRequest) error {
+	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateProjectAttributesDeleteRequest(request admin.ProjectAttributesDeleteRequest) error {
+	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func ValidateProjectDomainAttributesUpdateRequest(request admin.ProjectDomainAttributesUpdateRequest) (
 	admin.MatchableResource, error) {
 	if request.Attributes == nil {
@@ -52,6 +68,28 @@ func ValidateProjectDomainAttributesUpdateRequest(request admin.ProjectDomainAtt
 
 	return validateMatchingAttributes(request.Attributes.MatchingAttributes,
 		fmt.Sprintf("%s-%s", request.Attributes.Project, request.Attributes.Domain))
+}
+
+func ValidateProjectDomainAttributesGetRequest(request admin.ProjectDomainAttributesGetRequest) error {
+	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(request.Domain, shared.Domain); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateProjectDomainAttributesDeleteRequest(request admin.ProjectDomainAttributesDeleteRequest) error {
+	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(request.Domain, shared.Domain); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func ValidateWorkflowAttributesUpdateRequest(request admin.WorkflowAttributesUpdateRequest) (
@@ -71,4 +109,32 @@ func ValidateWorkflowAttributesUpdateRequest(request admin.WorkflowAttributesUpd
 
 	return validateMatchingAttributes(request.Attributes.MatchingAttributes,
 		fmt.Sprintf("%s-%s-%s", request.Attributes.Project, request.Attributes.Domain, request.Attributes.Workflow))
+}
+
+func ValidateWorkflowAttributesGetRequest(request admin.WorkflowAttributesGetRequest) error {
+	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(request.Domain, shared.Domain); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(request.Workflow, shared.Name); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateWorkflowAttributesDeleteRequest(request admin.WorkflowAttributesDeleteRequest) error {
+	if err := ValidateEmptyStringField(request.Project, shared.Project); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(request.Domain, shared.Domain); err != nil {
+		return err
+	}
+	if err := ValidateEmptyStringField(request.Workflow, shared.Name); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/manager/impl/validation/attributes_validator_test.go
+++ b/pkg/manager/impl/validation/attributes_validator_test.go
@@ -95,6 +95,24 @@ func TestValidateProjectAttributesUpdateRequest(t *testing.T) {
 	assert.Nil(t, err)
 }
 
+func TestValidateProjectAttributesGetRequest(t *testing.T) {
+	err := ValidateProjectAttributesGetRequest(admin.ProjectAttributesGetRequest{})
+	assert.Equal(t, "missing project", err.Error())
+
+	assert.Nil(t, ValidateProjectAttributesGetRequest(admin.ProjectAttributesGetRequest{
+		Project: "project",
+	}))
+}
+
+func TestValidateProjectAttributesDeleteRequest(t *testing.T) {
+	err := ValidateProjectAttributesDeleteRequest(admin.ProjectAttributesDeleteRequest{})
+	assert.Equal(t, "missing project", err.Error())
+
+	assert.Nil(t, ValidateProjectAttributesDeleteRequest(admin.ProjectAttributesDeleteRequest{
+		Project: "project",
+	}))
+}
+
 func TestValidateProjectDomainAttributesUpdateRequest(t *testing.T) {
 	_, err := ValidateProjectDomainAttributesUpdateRequest(admin.ProjectDomainAttributesUpdateRequest{})
 	assert.Equal(t, "missing attributes", err.Error())
@@ -125,6 +143,36 @@ func TestValidateProjectDomainAttributesUpdateRequest(t *testing.T) {
 		}})
 	assert.Equal(t, admin.MatchableResource_CLUSTER_RESOURCE, matchableResource)
 	assert.Nil(t, err)
+}
+
+func TestValidateProjectDomainAttributesGetRequest(t *testing.T) {
+	err := ValidateProjectDomainAttributesGetRequest(admin.ProjectDomainAttributesGetRequest{})
+	assert.Equal(t, "missing project", err.Error())
+
+	err = ValidateProjectDomainAttributesGetRequest(admin.ProjectDomainAttributesGetRequest{
+		Project: "project",
+	})
+	assert.Equal(t, "missing domain", err.Error())
+
+	assert.Nil(t, ValidateProjectDomainAttributesGetRequest(admin.ProjectDomainAttributesGetRequest{
+		Project: "project",
+		Domain:  "domain",
+	}))
+}
+
+func TestValidateProjectDomainAttributesDeleteRequest(t *testing.T) {
+	err := ValidateProjectDomainAttributesDeleteRequest(admin.ProjectDomainAttributesDeleteRequest{})
+	assert.Equal(t, "missing project", err.Error())
+
+	err = ValidateProjectDomainAttributesDeleteRequest(admin.ProjectDomainAttributesDeleteRequest{
+		Project: "project",
+	})
+	assert.Equal(t, "missing domain", err.Error())
+
+	assert.Nil(t, ValidateProjectDomainAttributesDeleteRequest(admin.ProjectDomainAttributesDeleteRequest{
+		Project: "project",
+		Domain:  "domain",
+	}))
 }
 
 func TestValidateWorkflowAttributesUpdateRequest(t *testing.T) {
@@ -163,4 +211,48 @@ func TestValidateWorkflowAttributesUpdateRequest(t *testing.T) {
 		}})
 	assert.Equal(t, admin.MatchableResource_EXECUTION_QUEUE, matchableResource)
 	assert.Nil(t, err)
+}
+
+func TestValidateWorkflowAttributesGetRequest(t *testing.T) {
+	err := ValidateWorkflowAttributesGetRequest(admin.WorkflowAttributesGetRequest{})
+	assert.Equal(t, "missing project", err.Error())
+
+	err = ValidateWorkflowAttributesGetRequest(admin.WorkflowAttributesGetRequest{
+		Project: "project",
+	})
+	assert.Equal(t, "missing domain", err.Error())
+
+	err = ValidateWorkflowAttributesGetRequest(admin.WorkflowAttributesGetRequest{
+		Project: "project",
+		Domain:  "domain",
+	})
+	assert.Equal(t, "missing name", err.Error())
+
+	assert.Nil(t, ValidateWorkflowAttributesGetRequest(admin.WorkflowAttributesGetRequest{
+		Project:  "project",
+		Domain:   "domain",
+		Workflow: "workflow",
+	}))
+}
+
+func TestValidateWorkflowAttributesDeleteRequest(t *testing.T) {
+	err := ValidateWorkflowAttributesDeleteRequest(admin.WorkflowAttributesDeleteRequest{})
+	assert.Equal(t, "missing project", err.Error())
+
+	err = ValidateWorkflowAttributesDeleteRequest(admin.WorkflowAttributesDeleteRequest{
+		Project: "project",
+	})
+	assert.Equal(t, "missing domain", err.Error())
+
+	err = ValidateWorkflowAttributesDeleteRequest(admin.WorkflowAttributesDeleteRequest{
+		Project: "project",
+		Domain:  "domain",
+	})
+	assert.Equal(t, "missing name", err.Error())
+
+	assert.Nil(t, ValidateWorkflowAttributesDeleteRequest(admin.WorkflowAttributesDeleteRequest{
+		Project:  "project",
+		Domain:   "domain",
+		Workflow: "workflow",
+	}))
 }

--- a/pkg/manager/impl/workflow_attributes_manager.go
+++ b/pkg/manager/impl/workflow_attributes_manager.go
@@ -36,6 +36,38 @@ func (m *WorkflowAttributesManager) UpdateWorkflowAttributes(
 	return &admin.WorkflowAttributesUpdateResponse{}, nil
 }
 
+func (m *WorkflowAttributesManager) GetWorkflowAttributes(
+	ctx context.Context, request admin.WorkflowAttributesGetRequest) (
+	*admin.WorkflowAttributesGetResponse, error) {
+	if err := validation.ValidateWorkflowAttributesGetRequest(request); err != nil {
+		return nil, err
+	}
+	projectAttributesModel, err := m.db.WorkflowAttributesRepo().Get(
+		ctx, request.Project, request.Domain, request.Workflow, request.ResourceType.String())
+	if err != nil {
+		return nil, err
+	}
+	projectAttributes, err := transformers.FromWorkflowAttributesModel(projectAttributesModel)
+	if err != nil {
+		return nil, err
+	}
+	return &admin.WorkflowAttributesGetResponse{
+		Attributes: &projectAttributes,
+	}, nil
+}
+
+func (m *WorkflowAttributesManager) DeleteWorkflowAttributes(ctx context.Context,
+	request admin.WorkflowAttributesDeleteRequest) (*admin.WorkflowAttributesDeleteResponse, error) {
+	if err := validation.ValidateWorkflowAttributesDeleteRequest(request); err != nil {
+		return nil, err
+	}
+	if err := m.db.WorkflowAttributesRepo().Delete(
+		ctx, request.Project, request.Domain, request.Workflow, request.ResourceType.String()); err != nil {
+		return nil, err
+	}
+	return &admin.WorkflowAttributesDeleteResponse{}, nil
+}
+
 func NewWorkflowAttributesManager(db repositories.RepositoryInterface) interfaces.WorkflowAttributesInterface {
 	return &WorkflowAttributesManager{
 		db: db,

--- a/pkg/manager/interfaces/project_attributes.go
+++ b/pkg/manager/interfaces/project_attributes.go
@@ -10,4 +10,8 @@ import (
 type ProjectAttributesInterface interface {
 	UpdateProjectAttributes(ctx context.Context, request admin.ProjectAttributesUpdateRequest) (
 		*admin.ProjectAttributesUpdateResponse, error)
+	GetProjectAttributes(ctx context.Context, request admin.ProjectAttributesGetRequest) (
+		*admin.ProjectAttributesGetResponse, error)
+	DeleteProjectAttributes(ctx context.Context, request admin.ProjectAttributesDeleteRequest) (
+		*admin.ProjectAttributesDeleteResponse, error)
 }

--- a/pkg/manager/interfaces/project_domain_attributes.go
+++ b/pkg/manager/interfaces/project_domain_attributes.go
@@ -10,4 +10,8 @@ import (
 type ProjectDomainAttributesInterface interface {
 	UpdateProjectDomainAttributes(ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
 		*admin.ProjectDomainAttributesUpdateResponse, error)
+	GetProjectDomainAttributes(ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+		*admin.ProjectDomainAttributesGetResponse, error)
+	DeleteProjectDomainAttributes(ctx context.Context, request admin.ProjectDomainAttributesDeleteRequest) (
+		*admin.ProjectDomainAttributesDeleteResponse, error)
 }

--- a/pkg/manager/interfaces/workflow_attributes.go
+++ b/pkg/manager/interfaces/workflow_attributes.go
@@ -10,4 +10,8 @@ import (
 type WorkflowAttributesInterface interface {
 	UpdateWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesUpdateRequest) (
 		*admin.WorkflowAttributesUpdateResponse, error)
+	GetWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesGetRequest) (
+		*admin.WorkflowAttributesGetResponse, error)
+	DeleteWorkflowAttributes(ctx context.Context, request admin.WorkflowAttributesDeleteRequest) (
+		*admin.WorkflowAttributesDeleteResponse, error)
 }

--- a/pkg/manager/mocks/project_domain.go
+++ b/pkg/manager/mocks/project_domain.go
@@ -8,20 +8,44 @@ import (
 
 type UpdateProjectDomainFunc func(ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error)
+type GetProjectDomainFunc func(ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+	*admin.ProjectDomainAttributesGetResponse, error)
+type DeleteProjectDomainFunc func(ctx context.Context, request admin.ProjectDomainAttributesDeleteRequest) (
+	*admin.ProjectDomainAttributesDeleteResponse, error)
 
-type MockProjectDomainManager struct {
+type MockProjectDomainAttributesManager struct {
 	updateProjectDomainFunc UpdateProjectDomainFunc
+	GetFunc                 GetProjectDomainFunc
+	DeleteFunc              DeleteProjectDomainFunc
 }
 
-func (m *MockProjectDomainManager) SetUpdateProjectDomainAttributes(updateProjectDomainFunc UpdateProjectDomainFunc) {
+func (m *MockProjectDomainAttributesManager) SetUpdateProjectDomainAttributes(updateProjectDomainFunc UpdateProjectDomainFunc) {
 	m.updateProjectDomainFunc = updateProjectDomainFunc
 }
 
-func (m *MockProjectDomainManager) UpdateProjectDomainAttributes(
+func (m *MockProjectDomainAttributesManager) UpdateProjectDomainAttributes(
 	ctx context.Context, request admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error) {
 	if m.updateProjectDomainFunc != nil {
 		return m.updateProjectDomainFunc(ctx, request)
+	}
+	return nil, nil
+}
+
+func (m *MockProjectDomainAttributesManager) GetProjectDomainAttributes(
+	ctx context.Context, request admin.ProjectDomainAttributesGetRequest) (
+	*admin.ProjectDomainAttributesGetResponse, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, request)
+	}
+	return nil, nil
+}
+
+func (m *MockProjectDomainAttributesManager) DeleteProjectDomainAttributes(
+	ctx context.Context, request admin.ProjectDomainAttributesDeleteRequest) (
+	*admin.ProjectDomainAttributesDeleteResponse, error) {
+	if m.DeleteFunc != nil {
+		return m.DeleteFunc(ctx, request)
 	}
 	return nil, nil
 }

--- a/pkg/repositories/gormimpl/metrics.go
+++ b/pkg/repositories/gormimpl/metrics.go
@@ -14,6 +14,7 @@ type gormMetrics struct {
 	UpdateDuration          promutils.StopWatch
 	ListDuration            promutils.StopWatch
 	ListIdentifiersDuration promutils.StopWatch
+	DeleteDuration          promutils.StopWatch
 }
 
 func newMetrics(scope promutils.Scope) gormMetrics {
@@ -29,5 +30,6 @@ func newMetrics(scope promutils.Scope) gormMetrics {
 			"list", "time taken to list entries", time.Millisecond),
 		ListIdentifiersDuration: scope.MustNewStopWatch(
 			"list_identifiers", "time taken to list identifier entries", time.Millisecond),
+		DeleteDuration: scope.MustNewStopWatch("delete", "time taken to delete an individual entry", time.Millisecond),
 	}
 }

--- a/pkg/repositories/gormimpl/project_attributes_repo_test.go
+++ b/pkg/repositories/gormimpl/project_attributes_repo_test.go
@@ -55,3 +55,17 @@ func TestGetProjectAttributes(t *testing.T) {
 	assert.Equal(t, testResourceAttr, output.Resource)
 	assert.Equal(t, []byte("attrs"), output.Attributes)
 }
+
+func TestDeleteProjectAttributes(t *testing.T) {
+	projectRepo := NewProjectAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	GlobalMock := mocket.Catcher.Reset()
+
+	query := GlobalMock.NewMock()
+	fakeResponse := query.WithQuery(
+		`DELETE FROM "project_attributes"  WHERE ("project_attributes"."project" = ?) AND ` +
+			`("project_attributes"."resource" = ?)`)
+
+	err := projectRepo.Delete(context.Background(), "project", "resource")
+	assert.Nil(t, err)
+	assert.True(t, fakeResponse.Triggered)
+}

--- a/pkg/repositories/gormimpl/project_domain_attributes_repo_test.go
+++ b/pkg/repositories/gormimpl/project_domain_attributes_repo_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestCreateProjectDomainAttributes(t *testing.T) {
-	projectRepo := NewProjectDomainAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	projectDomainRepo := NewProjectDomainAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
 	GlobalMock := mocket.Catcher.Reset()
 
 	query := GlobalMock.NewMock()
@@ -20,7 +20,7 @@ func TestCreateProjectDomainAttributes(t *testing.T) {
 		`INSERT  INTO "project_domain_attributes" ` +
 			`("created_at","updated_at","deleted_at","project","domain","resource","attributes") VALUES (?,?,?,?,?,?,?)`)
 
-	err := projectRepo.CreateOrUpdate(context.Background(), models.ProjectDomainAttributes{
+	err := projectDomainRepo.CreateOrUpdate(context.Background(), models.ProjectDomainAttributes{
 		Project:    "project",
 		Domain:     "domain",
 		Resource:   "resource",
@@ -31,7 +31,7 @@ func TestCreateProjectDomainAttributes(t *testing.T) {
 }
 
 func TestGetProjectDomainAttributes(t *testing.T) {
-	projectRepo := NewProjectDomainAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	projectDomainRepo := NewProjectDomainAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
 	GlobalMock := mocket.Catcher.Reset()
 
 	response := make(map[string]interface{})
@@ -49,10 +49,24 @@ func TestGetProjectDomainAttributes(t *testing.T) {
 			response,
 		})
 
-	output, err := projectRepo.Get(context.Background(), "project", "domain", "resource")
+	output, err := projectDomainRepo.Get(context.Background(), "project", "domain", "resource")
 	assert.Nil(t, err)
 	assert.Equal(t, "project", output.Project)
 	assert.Equal(t, "domain", output.Domain)
 	assert.Equal(t, "resource", output.Resource)
 	assert.Equal(t, []byte("attrs"), output.Attributes)
+}
+
+func TestDeleteProjectDomainAttributes(t *testing.T) {
+	projectDomainRepo := NewProjectDomainAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	GlobalMock := mocket.Catcher.Reset()
+
+	query := GlobalMock.NewMock()
+	fakeResponse := query.WithQuery(
+		`DELETE FROM "project_domain_attributes"  WHERE ("project_domain_attributes"."project" = ?) AND ` +
+			`("project_domain_attributes"."domain" = ?) AND ("project_domain_attributes"."resource" = ?)`)
+
+	err := projectDomainRepo.Delete(context.Background(), "project", "domain", "resource")
+	assert.Nil(t, err)
+	assert.True(t, fakeResponse.Triggered)
 }

--- a/pkg/repositories/gormimpl/workflow_attributes_repo_test.go
+++ b/pkg/repositories/gormimpl/workflow_attributes_repo_test.go
@@ -60,3 +60,18 @@ func TestGetWorkflowAttributes(t *testing.T) {
 	assert.Equal(t, "resource", output.Resource)
 	assert.Equal(t, []byte("attrs"), output.Attributes)
 }
+
+func TestDeleteWorkflowAttributes(t *testing.T) {
+	workflowRepo := NewWorkflowAttributesRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	GlobalMock := mocket.Catcher.Reset()
+
+	query := GlobalMock.NewMock()
+	fakeResponse := query.WithQuery(
+		`DELETE FROM "workflow_attributes"  WHERE ("workflow_attributes"."project" = ?) AND ` +
+			`("workflow_attributes"."domain" = ?) AND ("workflow_attributes"."workflow" = ?) AND ` +
+			`("workflow_attributes"."resource" = ?)`)
+
+	err := workflowRepo.Delete(context.Background(), "project", "domain", "workflow", "resource")
+	assert.Nil(t, err)
+	assert.True(t, fakeResponse.Triggered)
+}

--- a/pkg/repositories/interfaces/project_attributes_repo.go
+++ b/pkg/repositories/interfaces/project_attributes_repo.go
@@ -11,4 +11,6 @@ type ProjectAttributesRepoInterface interface {
 	CreateOrUpdate(ctx context.Context, input models.ProjectAttributes) error
 	// Returns a matching ProjectAttributes model when it exists.
 	Get(ctx context.Context, project, resource string) (models.ProjectAttributes, error)
+	// Deletes a matching ProjectAttributes model when it exists.
+	Delete(ctx context.Context, project, resource string) error
 }

--- a/pkg/repositories/interfaces/project_domain_attributes_repo.go
+++ b/pkg/repositories/interfaces/project_domain_attributes_repo.go
@@ -11,4 +11,6 @@ type ProjectDomainAttributesRepoInterface interface {
 	CreateOrUpdate(ctx context.Context, input models.ProjectDomainAttributes) error
 	// Returns a matching ProjectDomainAttributes model when it exists.
 	Get(ctx context.Context, project, domain, resource string) (models.ProjectDomainAttributes, error)
+	// Deletes a matching ProjectDomainAttributes model when it exists.
+	Delete(ctx context.Context, project, domain, resource string) error
 }

--- a/pkg/repositories/interfaces/workflow_attributes_repo.go
+++ b/pkg/repositories/interfaces/workflow_attributes_repo.go
@@ -11,4 +11,6 @@ type WorkflowAttributesRepoInterface interface {
 	CreateOrUpdate(ctx context.Context, input models.WorkflowAttributes) error
 	// Returns a matching WorkflowAttributes model when it exists.
 	Get(ctx context.Context, project, domain, workflow, resource string) (models.WorkflowAttributes, error)
+	// Deletes a matching ProjectDomainAttributes model when it exists.
+	Delete(ctx context.Context, project, domain, workflow, resource string) error
 }

--- a/pkg/repositories/mocks/project_attributes_repo.go
+++ b/pkg/repositories/mocks/project_attributes_repo.go
@@ -9,10 +9,12 @@ import (
 
 type CreateOrUpdateProjectAttributesFunction func(ctx context.Context, input models.ProjectAttributes) error
 type GetProjectAttributesFunction func(ctx context.Context, project, resource string) (models.ProjectAttributes, error)
+type DeleteProjectAttributesFunction func(ctx context.Context, project, resource string) error
 
 type MockProjectAttributesRepo struct {
 	CreateOrUpdateFunction CreateOrUpdateProjectAttributesFunction
 	GetFunction            GetProjectAttributesFunction
+	DeleteFunction         DeleteProjectAttributesFunction
 }
 
 func (r *MockProjectAttributesRepo) CreateOrUpdate(ctx context.Context, input models.ProjectAttributes) error {
@@ -28,6 +30,13 @@ func (r *MockProjectAttributesRepo) Get(ctx context.Context, project, resource s
 		return r.GetFunction(ctx, project, resource)
 	}
 	return models.ProjectAttributes{}, nil
+}
+
+func (r *MockProjectAttributesRepo) Delete(ctx context.Context, project, resource string) error {
+	if r.DeleteFunction != nil {
+		return r.DeleteFunction(ctx, project, resource)
+	}
+	return nil
 }
 
 func NewMockProjectAttributesRepo() interfaces.ProjectAttributesRepoInterface {

--- a/pkg/repositories/mocks/project_domain_attributes_repo.go
+++ b/pkg/repositories/mocks/project_domain_attributes_repo.go
@@ -9,10 +9,12 @@ import (
 
 type CreateOrUpdateProjectDomainAttributesFunction func(ctx context.Context, input models.ProjectDomainAttributes) error
 type GetProjectDomainAttributesFunction func(ctx context.Context, project, domain, resource string) (models.ProjectDomainAttributes, error)
+type DeleteProjectDomainAttributesFunction func(ctx context.Context, project, domain, resource string) error
 
 type MockProjectDomainAttributesRepo struct {
 	CreateOrUpdateFunction CreateOrUpdateProjectDomainAttributesFunction
 	GetFunction            GetProjectDomainAttributesFunction
+	DeleteFunction         DeleteProjectDomainAttributesFunction
 }
 
 func (r *MockProjectDomainAttributesRepo) CreateOrUpdate(ctx context.Context, input models.ProjectDomainAttributes) error {
@@ -28,6 +30,13 @@ func (r *MockProjectDomainAttributesRepo) Get(ctx context.Context, project, doma
 		return r.GetFunction(ctx, project, domain, resource)
 	}
 	return models.ProjectDomainAttributes{}, nil
+}
+
+func (r *MockProjectDomainAttributesRepo) Delete(ctx context.Context, project, domain, resource string) error {
+	if r.DeleteFunction != nil {
+		return r.DeleteFunction(ctx, project, domain, resource)
+	}
+	return nil
 }
 
 func NewMockProjectDomainAttributesRepo() interfaces.ProjectDomainAttributesRepoInterface {

--- a/pkg/repositories/mocks/workflow_attributes.go
+++ b/pkg/repositories/mocks/workflow_attributes.go
@@ -10,11 +10,12 @@ import (
 type CreateOrUpdateWorkflowAttributesFunction func(ctx context.Context, input models.WorkflowAttributes) error
 type GetWorkflowAttributesFunction func(ctx context.Context, project, domain, workflow, resource string) (
 	models.WorkflowAttributes, error)
-type UpdateWorkflowAttributesFunction func(ctx context.Context, input models.WorkflowAttributes) error
+type DeleteWorkflowAttributesFunction func(ctx context.Context, project, domain, workflow, resource string) error
 
 type MockWorkflowAttributesRepo struct {
 	CreateOrUpdateFunction CreateOrUpdateWorkflowAttributesFunction
 	GetFunction            GetWorkflowAttributesFunction
+	DeleteFunction         DeleteWorkflowAttributesFunction
 }
 
 func (r *MockWorkflowAttributesRepo) CreateOrUpdate(ctx context.Context, input models.WorkflowAttributes) error {
@@ -30,6 +31,13 @@ func (r *MockWorkflowAttributesRepo) Get(ctx context.Context, project, domain, w
 		return r.GetFunction(ctx, project, domain, workflow, resource)
 	}
 	return models.WorkflowAttributes{}, nil
+}
+
+func (r *MockWorkflowAttributesRepo) Delete(ctx context.Context, project, domain, workflow, resource string) error {
+	if r.DeleteFunction != nil {
+		return r.DeleteFunction(ctx, project, domain, workflow, resource)
+	}
+	return nil
 }
 
 func NewMockWorkflowAttributesRepo() interfaces.WorkflowAttributesRepoInterface {

--- a/pkg/rpc/adminservice/attributes.go
+++ b/pkg/rpc/adminservice/attributes.go
@@ -27,6 +27,42 @@ func (m *AdminService) UpdateWorkflowAttributes(ctx context.Context, request *ad
 	return response, nil
 }
 
+func (m *AdminService) GetWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesGetRequest) (
+	*admin.WorkflowAttributesGetResponse, error) {
+	defer m.interceptPanic(ctx, request)
+	if request == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
+	}
+	var response *admin.WorkflowAttributesGetResponse
+	var err error
+	m.Metrics.workflowAttributesEndpointMetrics.get.Time(func() {
+		response, err = m.WorkflowAttributesManager.GetWorkflowAttributes(ctx, *request)
+	})
+	if err != nil {
+		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.get)
+	}
+
+	return response, nil
+}
+
+func (m *AdminService) DeleteWorkflowAttributes(ctx context.Context, request *admin.WorkflowAttributesDeleteRequest) (
+	*admin.WorkflowAttributesDeleteResponse, error) {
+	defer m.interceptPanic(ctx, request)
+	if request == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
+	}
+	var response *admin.WorkflowAttributesDeleteResponse
+	var err error
+	m.Metrics.workflowAttributesEndpointMetrics.delete.Time(func() {
+		response, err = m.WorkflowAttributesManager.DeleteWorkflowAttributes(ctx, *request)
+	})
+	if err != nil {
+		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.delete)
+	}
+
+	return response, nil
+}
+
 func (m *AdminService) UpdateProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesUpdateRequest) (
 	*admin.ProjectDomainAttributesUpdateResponse, error) {
 	defer m.interceptPanic(ctx, request)
@@ -45,6 +81,42 @@ func (m *AdminService) UpdateProjectDomainAttributes(ctx context.Context, reques
 	return response, nil
 }
 
+func (m *AdminService) GetProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesGetRequest) (
+	*admin.ProjectDomainAttributesGetResponse, error) {
+	defer m.interceptPanic(ctx, request)
+	if request == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
+	}
+	var response *admin.ProjectDomainAttributesGetResponse
+	var err error
+	m.Metrics.workflowAttributesEndpointMetrics.get.Time(func() {
+		response, err = m.ProjectDomainAttributesManager.GetProjectDomainAttributes(ctx, *request)
+	})
+	if err != nil {
+		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.get)
+	}
+
+	return response, nil
+}
+
+func (m *AdminService) DeleteProjectDomainAttributes(ctx context.Context, request *admin.ProjectDomainAttributesDeleteRequest) (
+	*admin.ProjectDomainAttributesDeleteResponse, error) {
+	defer m.interceptPanic(ctx, request)
+	if request == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
+	}
+	var response *admin.ProjectDomainAttributesDeleteResponse
+	var err error
+	m.Metrics.workflowAttributesEndpointMetrics.delete.Time(func() {
+		response, err = m.ProjectDomainAttributesManager.DeleteProjectDomainAttributes(ctx, *request)
+	})
+	if err != nil {
+		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.delete)
+	}
+
+	return response, nil
+}
+
 func (m *AdminService) UpdateProjectAttributes(ctx context.Context, request *admin.ProjectAttributesUpdateRequest) (
 	*admin.ProjectAttributesUpdateResponse, error) {
 	defer m.interceptPanic(ctx, request)
@@ -58,6 +130,42 @@ func (m *AdminService) UpdateProjectAttributes(ctx context.Context, request *adm
 	})
 	if err != nil {
 		return nil, util.TransformAndRecordError(err, &m.Metrics.projectAttributesEndpointMetrics.update)
+	}
+
+	return response, nil
+}
+
+func (m *AdminService) GetProjectAttributes(ctx context.Context, request *admin.ProjectAttributesGetRequest) (
+	*admin.ProjectAttributesGetResponse, error) {
+	defer m.interceptPanic(ctx, request)
+	if request == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
+	}
+	var response *admin.ProjectAttributesGetResponse
+	var err error
+	m.Metrics.workflowAttributesEndpointMetrics.get.Time(func() {
+		response, err = m.ProjectAttributesManager.GetProjectAttributes(ctx, *request)
+	})
+	if err != nil {
+		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.get)
+	}
+
+	return response, nil
+}
+
+func (m *AdminService) DeleteProjectAttributes(ctx context.Context, request *admin.ProjectAttributesDeleteRequest) (
+	*admin.ProjectAttributesDeleteResponse, error) {
+	defer m.interceptPanic(ctx, request)
+	if request == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "Incorrect request, nil requests not allowed")
+	}
+	var response *admin.ProjectAttributesDeleteResponse
+	var err error
+	m.Metrics.workflowAttributesEndpointMetrics.delete.Time(func() {
+		response, err = m.ProjectAttributesManager.DeleteProjectAttributes(ctx, *request)
+	})
+	if err != nil {
+		return nil, util.TransformAndRecordError(err, &m.Metrics.workflowAttributesEndpointMetrics.delete)
 	}
 
 	return response, nil

--- a/pkg/rpc/adminservice/metrics.go
+++ b/pkg/rpc/adminservice/metrics.go
@@ -60,6 +60,8 @@ type attributeEndpointMetrics struct {
 	scope promutils.Scope
 
 	update util.RequestMetrics
+	get    util.RequestMetrics
+	delete util.RequestMetrics
 }
 
 type taskEndpointMetrics struct {
@@ -154,14 +156,20 @@ func InitMetrics(adminScope promutils.Scope) AdminMetrics {
 		projectAttributesEndpointMetrics: attributeEndpointMetrics{
 			scope:  adminScope,
 			update: util.NewRequestMetrics(adminScope, "update_project_attrs"),
+			get:    util.NewRequestMetrics(adminScope, "get_project_attrs"),
+			delete: util.NewRequestMetrics(adminScope, "delete_project_attrs"),
 		},
 		projectDomainAttributesEndpointMetrics: attributeEndpointMetrics{
 			scope:  adminScope,
 			update: util.NewRequestMetrics(adminScope, "update_project_domain_attrs"),
+			get:    util.NewRequestMetrics(adminScope, "get_project_domain_attrs"),
+			delete: util.NewRequestMetrics(adminScope, "delete_project_domain_attrs"),
 		},
 		workflowAttributesEndpointMetrics: attributeEndpointMetrics{
 			scope:  adminScope,
 			update: util.NewRequestMetrics(adminScope, "update_workflow_attrs"),
+			get:    util.NewRequestMetrics(adminScope, "get_workflow_attrs"),
+			delete: util.NewRequestMetrics(adminScope, "delete_workflow_attrs"),
 		},
 		taskEndpointMetrics: taskEndpointMetrics{
 			scope:   adminScope,

--- a/pkg/rpc/adminservice/tests/project_domain_test.go
+++ b/pkg/rpc/adminservice/tests/project_domain_test.go
@@ -12,7 +12,7 @@ import (
 func TestUpdateProjectDomain(t *testing.T) {
 	ctx := context.Background()
 
-	mockProjectDomainManager := mocks.MockProjectDomainManager{}
+	mockProjectDomainManager := mocks.MockProjectDomainAttributesManager{}
 	var updateCalled bool
 	mockProjectDomainManager.SetUpdateProjectDomainAttributes(
 		func(ctx context.Context,
@@ -22,7 +22,7 @@ func TestUpdateProjectDomain(t *testing.T) {
 		},
 	)
 	mockServer := NewMockAdminServer(NewMockAdminServerInput{
-		projectDomainManager: &mockProjectDomainManager,
+		projectDomainAttributesManager: &mockProjectDomainManager,
 	})
 
 	resp, err := mockServer.UpdateProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesUpdateRequest{})

--- a/pkg/rpc/adminservice/tests/util.go
+++ b/pkg/rpc/adminservice/tests/util.go
@@ -7,14 +7,14 @@ import (
 )
 
 type NewMockAdminServerInput struct {
-	executionManager     *mocks.MockExecutionManager
-	launchPlanManager    *mocks.MockLaunchPlanManager
-	nodeExecutionManager *mocks.MockNodeExecutionManager
-	projectManager       *mocks.MockProjectManager
-	projectDomainManager *mocks.MockProjectDomainManager
-	taskManager          *mocks.MockTaskManager
-	workflowManager      *mocks.MockWorkflowManager
-	taskExecutionManager *mocks.MockTaskExecutionManager
+	executionManager               *mocks.MockExecutionManager
+	launchPlanManager              *mocks.MockLaunchPlanManager
+	nodeExecutionManager           *mocks.MockNodeExecutionManager
+	projectManager                 *mocks.MockProjectManager
+	projectDomainAttributesManager *mocks.MockProjectDomainAttributesManager
+	taskManager                    *mocks.MockTaskManager
+	workflowManager                *mocks.MockWorkflowManager
+	taskExecutionManager           *mocks.MockTaskExecutionManager
 }
 
 func NewMockAdminServer(input NewMockAdminServerInput) *adminservice.AdminService {
@@ -25,7 +25,7 @@ func NewMockAdminServer(input NewMockAdminServerInput) *adminservice.AdminServic
 		NodeExecutionManager:           input.nodeExecutionManager,
 		TaskManager:                    input.taskManager,
 		ProjectManager:                 input.projectManager,
-		ProjectDomainAttributesManager: input.projectDomainManager,
+		ProjectDomainAttributesManager: input.projectDomainAttributesManager,
 		WorkflowManager:                input.workflowManager,
 		TaskExecutionManager:           input.taskExecutionManager,
 		Metrics:                        adminservice.InitMetrics(testScope),

--- a/tests/attributes_test.go
+++ b/tests/attributes_test.go
@@ -8,10 +8,6 @@ import (
 
 	"github.com/golang/protobuf/proto"
 
-	"github.com/lyft/flyteadmin/pkg/repositories/errors"
-	"github.com/lyft/flyteadmin/pkg/repositories/gormimpl"
-	"github.com/lyft/flyteadmin/pkg/repositories/transformers"
-
 	"github.com/stretchr/testify/assert"
 
 	databaseConfig "github.com/lyft/flyteadmin/pkg/repositories/config"
@@ -28,8 +24,13 @@ var matchingAttributes = &admin.MatchingAttributes{
 	},
 }
 
-func TestUpdateProjectAttributes(t *testing.T) {
+func TestProjectAttributes(t *testing.T) {
 	ctx := context.Background()
+
+	db := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getLocalDbConfig(), adminScope))
+	truncateTableForTesting(db, "project_attributes")
+	db.Close()
+
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
 
@@ -43,24 +44,39 @@ func TestUpdateProjectAttributes(t *testing.T) {
 	_, err := client.UpdateProjectAttributes(ctx, &req)
 	assert.Nil(t, err)
 
-	// If we ever expose get/list ProjectAttributes APIs update the test below to call those instead.
-	db := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(geDbConfig(), adminScope))
-	defer db.Close()
+	response, err := client.GetProjectAttributes(ctx, &admin.ProjectAttributesGetRequest{
+		Project:      "admintests",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.ProjectAttributesGetResponse{
+		Attributes: &admin.ProjectAttributes{
+			Project:            "admintests",
+			MatchingAttributes: matchingAttributes,
+		},
+	}, response))
 
-	errorsTransformer := errors.NewPostgresErrorTransformer(adminScope.NewSubScope("project_attrs_errors"))
-	projectRepo := gormimpl.NewProjectAttributesRepo(db, errorsTransformer, adminScope.NewSubScope("project_attrs"))
-
-	attributes, err := projectRepo.Get(ctx, "admintests", admin.MatchableResource_TASK_RESOURCE.String())
+	_, err = client.DeleteProjectAttributes(ctx, &admin.ProjectAttributesDeleteRequest{
+		Project:      "admintests",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
 	assert.Nil(t, err)
 
-	projectAttributes, err := transformers.FromProjectAttributesModel(attributes)
-	assert.True(t, proto.Equal(matchingAttributes, projectAttributes.MatchingAttributes))
+	_, err = client.GetProjectAttributes(ctx, &admin.ProjectAttributesGetRequest{
+		Project:      "admintests",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	assert.EqualError(t, err, "rpc error: code = NotFound desc = entry not found")
 }
 
 func TestUpdateProjectDomainAttributes(t *testing.T) {
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
+
+	db := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getLocalDbConfig(), adminScope))
+	truncateTableForTesting(db, "project_domain_attributes")
+	db.Close()
 
 	req := admin.ProjectDomainAttributesUpdateRequest{
 		Attributes: &admin.ProjectDomainAttributes{
@@ -73,25 +89,43 @@ func TestUpdateProjectDomainAttributes(t *testing.T) {
 	_, err := client.UpdateProjectDomainAttributes(ctx, &req)
 	assert.Nil(t, err)
 
-	// If we ever expose get/list ProjectDomainAttributes APIs update the test below to call those instead.
-	db := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getLocalDbConfig(), adminScope))
-	defer db.Close()
+	response, err := client.GetProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.ProjectDomainAttributesGetResponse{
+		Attributes: &admin.ProjectDomainAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			MatchingAttributes: matchingAttributes,
+		},
+	}, response))
 
-	errorsTransformer := errors.NewPostgresErrorTransformer(adminScope.NewSubScope("project_domain_attrs_errors"))
-	projectDomainRepo := gormimpl.NewProjectDomainAttributesRepo(db, errorsTransformer, adminScope.NewSubScope("project_domain_attrs"))
-
-	attributes, err := projectDomainRepo.Get(ctx, "admintests", "development",
-		admin.MatchableResource_TASK_RESOURCE.String())
+	_, err = client.DeleteProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesDeleteRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
 	assert.Nil(t, err)
 
-	projectDomainAttributes, err := transformers.FromProjectDomainAttributesModel(attributes)
-	assert.True(t, proto.Equal(matchingAttributes, projectDomainAttributes.MatchingAttributes))
+	_, err = client.GetProjectDomainAttributes(ctx, &admin.ProjectDomainAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	assert.EqualError(t, err, "rpc error: code = NotFound desc = entry not found")
 }
 
 func TestUpdateWorkflowAttributes(t *testing.T) {
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
+
+	db := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getLocalDbConfig(), adminScope))
+	truncateTableForTesting(db, "workflow_attributes")
+	db.Close()
 
 	req := admin.WorkflowAttributesUpdateRequest{
 		Attributes: &admin.WorkflowAttributes{
@@ -105,17 +139,35 @@ func TestUpdateWorkflowAttributes(t *testing.T) {
 	_, err := client.UpdateWorkflowAttributes(ctx, &req)
 	assert.Nil(t, err)
 
-	// If we ever expose get/list WorkflowAttributes APIs update the test below to call those instead.
-	db := databaseConfig.OpenDbConnection(databaseConfig.NewPostgresConfigProvider(getLocalDbConfig(), adminScope))
-	defer db.Close()
+	response, err := client.GetWorkflowAttributes(ctx, &admin.WorkflowAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		Workflow:     "workflow",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.WorkflowAttributesGetResponse{
+		Attributes: &admin.WorkflowAttributes{
+			Project:            "admintests",
+			Domain:             "development",
+			Workflow:           "workflow",
+			MatchingAttributes: matchingAttributes,
+		},
+	}, response))
 
-	errorsTransformer := errors.NewPostgresErrorTransformer(adminScope.NewSubScope("workflow_attrs_errors"))
-	workflowRepo := gormimpl.NewWorkflowAttributesRepo(db, errorsTransformer, adminScope.NewSubScope("workflow_attrs"))
-
-	attributes, err := workflowRepo.Get(ctx, "admintests", "development", "workflow",
-		admin.MatchableResource_TASK_RESOURCE.String())
+	_, err = client.DeleteWorkflowAttributes(ctx, &admin.WorkflowAttributesDeleteRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		Workflow:     "workflow",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
 	assert.Nil(t, err)
 
-	workflowAttributes, err := transformers.FromWorkflowAttributesModel(attributes)
-	assert.True(t, proto.Equal(matchingAttributes, workflowAttributes.MatchingAttributes))
+	_, err = client.GetWorkflowAttributes(ctx, &admin.WorkflowAttributesGetRequest{
+		Project:      "admintests",
+		Domain:       "development",
+		Workflow:     "workflow",
+		ResourceType: admin.MatchableResource_TASK_RESOURCE,
+	})
+	assert.EqualError(t, err, "rpc error: code = NotFound desc = entry not found")
 }

--- a/tests/bootstrap.go
+++ b/tests/bootstrap.go
@@ -5,6 +5,8 @@ package tests
 import (
 	"fmt"
 
+	"github.com/jinzhu/gorm"
+
 	database_config "github.com/lyft/flyteadmin/pkg/repositories/config"
 	"github.com/lyft/flytestdlib/promutils"
 )
@@ -32,6 +34,10 @@ func getLocalDbConfig() database_config.DbConfig {
 		DbName: "postgres",
 		User:   "postgres",
 	}
+}
+
+func truncateTableForTesting(db *gorm.DB, tableName string) {
+	db.Exec(fmt.Sprintf("TRUNCATE TABLE %s;", tableName))
 }
 
 func truncateAllTablesForTestingOnly() {


### PR DESCRIPTION
Currently ProjectAttributes, ProjectDomainAttributes and WorkflowAttributes can be used to specify resource overrides. This change implements a delete API for all these customizable attributes AND a get to check what the existing values are currently set as.

In the future, only system administrators will be able to mutate these values once we have authorization rolled out.