### PR TITLE
Add validation for cluster label

### DIFF
--- a/pkg/manager/impl/validation/attributes_validator.go
+++ b/pkg/manager/impl/validation/attributes_validator.go
@@ -21,6 +21,8 @@ func validateMatchingAttributes(attributes *admin.MatchingAttributes, identifier
 		return admin.MatchableResource_CLUSTER_RESOURCE, nil
 	} else if attributes.GetExecutionQueueAttributes() != nil {
 		return admin.MatchableResource_EXECUTION_QUEUE, nil
+	} else if attributes.GetExecutionClusterLabel() != nil {
+		return admin.MatchableResource_EXECUTION_CLUSTER_LABEL, nil
 	}
 	return defaultMatchableResource, errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 		"Unrecognized matching attributes type for request %s", identifier)


### PR DESCRIPTION
Needed to insert data for resource overrides before placement manager is deployed.