### PR TITLE
Use Update in sync cluster resources by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,6 +40,7 @@ require (
 	google.golang.org/genproto v0.0.0-20200312145019-da6875a35672 // indirect
 	google.golang.org/grpc v1.28.0
 	gopkg.in/gormigrate.v1 v1.6.0
+	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v11.0.0+incompatible
 	sigs.k8s.io/controller-runtime v0.5.1

--- a/pkg/clusterresource/controller.go
+++ b/pkg/clusterresource/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	v1 "k8s.io/api/rbac/v1"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,6 +85,14 @@ var descCreatedAtSortParam, _ = common.NewSortParameter(admin.Sort{
 	Direction: admin.Sort_DESCENDING,
 	Key:       "created_at",
 })
+
+// Use a strategic-merge-patch to mimic `kubectl apply` behavior for serviceaccounts.
+// Kubectl defaults to using the StrategicMergePatch strategy.
+// However the controller-runtime only has an implementation for MergePatch which we were formerly
+// using but failed to actually always merge resources in the Patch call.
+var strategicPatchTypes = map[string]bool {
+	v1.ServiceAccountKind: true,
+}
 
 func (c *controller) templateAlreadyApplied(namespace NamespaceName, templateFile os.FileInfo) bool {
 	namespacedAppliedTemplates, ok := c.appliedTemplates[namespace]
@@ -292,11 +301,15 @@ func (c *controller) syncNamespace(ctx context.Context, namespace NamespaceName,
 					logger.Debugf(ctx, "Type [%+v] in namespace [%s] already exists - attempting update instead",
 						k8sObj.GetObjectKind().GroupVersionKind().Kind, namespace)
 					c.metrics.AppliedTemplateExists.Inc()
-					// Use a strategic-merge-patch to mimic `kubectl apply` behavior.
-					// Kubectl defaults to using the StrategicMergePatch strategy.
-					// However the controller-runtime only has an implementation for MergePatch which we were formerly
-					// using but failed to actually always merge resources in the Patch call.
-					err = target.Client.Patch(ctx, k8sObjCopy, StrategicMergeFrom(k8sObjCopy))
+
+					logger.Warningf(ctx, "*** k8sObjCopy.GetObjectKind().GroupVersionKind().Kind is [%+v]," +
+						k8sObjCopy.GetObjectKind().GroupVersionKind().Kind)
+					if ok := strategicPatchTypes[k8sObjCopy.GetObjectKind().GroupVersionKind().Kind]; ok {
+						err = target.Client.Patch(ctx, k8sObjCopy, StrategicMergeFrom(k8sObjCopy))
+					} else {
+						err = target.Client.Update(ctx, k8sObjCopy)
+					}
+
 					if err != nil {
 						c.metrics.TemplateUpdateErrors.Inc()
 						logger.Infof(ctx, "Failed to update resource [%+v] in namespace [%s] with err :%v",

--- a/pkg/clusterresource/controller.go
+++ b/pkg/clusterresource/controller.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	v1 "k8s.io/api/rbac/v1"
 	"os"
 	"path"
 	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"time"
+
+	v1 "k8s.io/api/rbac/v1"
 
 	"github.com/lyft/flyteadmin/pkg/manager/impl/resources"
 	managerinterfaces "github.com/lyft/flyteadmin/pkg/manager/interfaces"
@@ -94,7 +95,7 @@ var descCreatedAtSortParam, _ = common.NewSortParameter(admin.Sort{
 // whitelist the specific set of resources that require a Patch to work instead.
 // If you use update with a ServiceAccount - *every* call to Update results in a new corresponding secret being created
 // which has the (not so) fun side-effect of overwhelming API server when this Sync script is run as a cron.
-var strategicPatchTypes = map[string]bool {
+var strategicPatchTypes = map[string]bool{
 	v1.ServiceAccountKind: true,
 }
 


### PR DESCRIPTION
# TL;DR
It turns out that updating kubernetes resources regularly (and successfully) requires the Update rest call. However, serviceaccount, special snowflake that it is, doesn't respect Update and will actually create a new corresponding secret each time Update is called, even if nothing changes across the original and to-Update resource. This change whitelists a set of resources for which to use StrategicMergePatch with when updating. This mimics the behavior `kubectl apply` uses when updating serviceaccounts. In the future, if we need to use other Patch strategies we can refactor this code - if necessary - to have the whitelist map to Patch Types.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested (local sandbox with docker desktop)
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
See PR description

## Tracking Issue
N/A

## Follow-up issue
N/A
