### PR TITLE
Improve ListNamedEntities perf: Use sub-query with group by 

### DIFF
--- a/pkg/manager/impl/named_entity_manager.go
+++ b/pkg/manager/impl/named_entity_manager.go
@@ -68,16 +68,15 @@ func (m *NamedEntityManager) GetNamedEntity(ctx context.Context, request admin.N
 	return util.GetNamedEntity(ctx, m.db, request.ResourceType, *request.Id)
 }
 
-func (m *NamedEntityManager) updateQueryFilters(identityFilters []common.InlineFilter, requestFilters string) (
-	[]common.InlineFilter, error) {
+func (m *NamedEntityManager) getQueryFilters(requestFilters string) ([]common.InlineFilter, error) {
+	filters := make([]common.InlineFilter, 0)
 	if len(requestFilters) == 0 {
-		return identityFilters, nil
+		return filters, nil
 	}
 	additionalFilters, err := util.ParseFilters(requestFilters, common.NamedEntityMetadata)
 	if err != nil {
 		return nil, err
 	}
-	var finalizedFilters = identityFilters
 	for _, filter := range additionalFilters {
 		if strings.Contains(filter.GetField(), state) {
 			filterWithDefaultValue, err := common.NewWithDefaultValueFilter(
@@ -85,12 +84,12 @@ func (m *NamedEntityManager) updateQueryFilters(identityFilters []common.InlineF
 			if err != nil {
 				return nil, err
 			}
-			finalizedFilters = append(finalizedFilters, filterWithDefaultValue)
+			filters = append(filters, filterWithDefaultValue)
 		} else {
-			finalizedFilters = append(finalizedFilters, filter)
+			filters = append(filters, filter)
 		}
 	}
-	return finalizedFilters, nil
+	return filters, nil
 }
 
 func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request admin.NamedEntityListRequest) (
@@ -101,17 +100,10 @@ func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request admi
 	}
 	ctx = contextutils.WithProjectDomain(ctx, request.Project, request.Domain)
 
-	identifierFilters, err := util.GetDbFilters(util.FilterSpec{
-		Project: request.Project,
-		Domain:  request.Domain,
-	}, common.ResourceTypeToEntity[request.ResourceType])
-	if err != nil {
-		return nil, err
-	}
 	// HACK: In order to filter by state (if requested) - we need to amend the filter to use COALESCE
 	// e.g. eq(state, 1) becomes 'WHERE (COALESCE(state, 0) = '1')' since not every NamedEntity necessarily
 	// has an entry, and therefore the default state value '0' (active), should be assumed.
-	filters, err := m.updateQueryFilters(identifierFilters, request.Filters)
+	filters, err := m.getQueryFilters(request.Filters)
 	if err != nil {
 		return nil, err
 	}
@@ -127,14 +119,19 @@ func (m *NamedEntityManager) ListNamedEntities(ctx context.Context, request admi
 		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 			"invalid pagination token %s for ListNamedEntities", request.Token)
 	}
-	listInput := repoInterfaces.ListResourceInput{
-		Limit:         int(request.Limit),
-		Offset:        offset,
-		InlineFilters: filters,
-		SortParameter: sortParameter,
+	listInput := repoInterfaces.ListNamedEntityInput{
+		ListResourceInput: repoInterfaces.ListResourceInput{
+			Limit:         int(request.Limit),
+			Offset:        offset,
+			InlineFilters: filters,
+			SortParameter: sortParameter,
+		},
+		Project:      request.Project,
+		Domain:       request.Domain,
+		ResourceType: request.ResourceType,
 	}
 
-	output, err := m.db.NamedEntityRepo().List(ctx, request.ResourceType, listInput)
+	output, err := m.db.NamedEntityRepo().List(ctx, listInput)
 	if err != nil {
 		logger.Debugf(ctx, "Failed to list named entities of type: %s with project: %s, domain: %s. Returned error was: %v",
 			request.ResourceType, request.Project, request.Domain, err)

--- a/pkg/manager/impl/named_entity_manager_test.go
+++ b/pkg/manager/impl/named_entity_manager_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/lyft/flyteadmin/pkg/common"
-
 	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
 	"github.com/lyft/flyteadmin/pkg/repositories"
 	"github.com/lyft/flyteadmin/pkg/repositories/interfaces"
@@ -86,21 +84,15 @@ func TestNamedEntityManager_Get_BadRequest(t *testing.T) {
 	assert.Nil(t, response)
 }
 
-func TestNamedEntityManager_UpdateQueryFilters(t *testing.T) {
-	identityFilter, err := common.NewSingleValueFilter(common.NamedEntityMetadata, common.Equal, "project", "proj")
-	assert.NoError(t, err)
-
+func TestNamedEntityManager_getQueryFilters(t *testing.T) {
 	repository := getMockRepositoryForNETest()
 	manager := NewNamedEntityManager(repository, getMockConfigForNETest(), mockScope.NewTestScope())
-	updatedFilters, err := manager.(*NamedEntityManager).updateQueryFilters([]common.InlineFilter{
-		identityFilter,
-	}, "eq(state, 0)")
+	updatedFilters, err := manager.(*NamedEntityManager).getQueryFilters("eq(state, 0)")
 	assert.NoError(t, err)
-	assert.Len(t, updatedFilters, 2)
+	assert.Len(t, updatedFilters, 1)
 
-	assert.Equal(t, "project", updatedFilters[0].GetField())
-	assert.Equal(t, "state", updatedFilters[1].GetField())
-	queryExp, err := updatedFilters[1].GetGormQueryExpr()
+	assert.Equal(t, "state", updatedFilters[0].GetField())
+	queryExp, err := updatedFilters[0].GetGormQueryExpr()
 	assert.NoError(t, err)
 	assert.Equal(t, "COALESCE(state, 0) = ?", queryExp.Query)
 	assert.Equal(t, "0", queryExp.Args)

--- a/pkg/repositories/gormimpl/named_entity_repo_test.go
+++ b/pkg/repositories/gormimpl/named_entity_repo_test.go
@@ -158,14 +158,9 @@ func TestListNamedEntity(t *testing.T) {
 	mockQuery := GlobalMock.NewMock()
 
 	mockQuery.WithQuery(
-		`SELECT entities.project, entities.domain, entities.name, '2' AS resource_type, ` +
-			`named_entity_metadata.description, named_entity_metadata.state FROM "named_entity_metadata" RIGHT JOIN ` +
-			`(SELECT project, domain, name FROM "workflows"  WHERE ("workflows"."project" = admintests) AND ` +
+		`(SELECT project, domain, name FROM "workflows"  WHERE ("workflows"."project" = admintests) AND ` +
 			`("workflows"."domain" = development) GROUP BY project, domain, name ORDER BY name desc LIMIT 20 ` +
-			`OFFSET 0) AS entities ON named_entity_metadata.resource_type = 2 AND named_entity_metadata.project = ` +
-			`entities.project AND named_entity_metadata.domain = entities.domain AND named_entity_metadata.name = ` +
-			`entities.name  GROUP BY entities.project, entities.domain, entities.name, ` +
-			`named_entity_metadata.description, named_entity_metadata.state ORDER BY name desc`).WithReply(results)
+			`OFFSET 0) AS entities`).WithReply(results)
 
 	sortParameter, _ := common.NewSortParameter(admin.Sort{
 		Direction: admin.Sort_DESCENDING,
@@ -182,9 +177,4 @@ func TestListNamedEntity(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.Len(t, output.Entities, 1)
-	/*assert.Equal(t, project, output.Entities[0].Project)
-	assert.Equal(t, domain, output.Entities[0].Domain)
-	assert.Equal(t, name, output.Entities[0].Name)
-	assert.Equal(t, resourceType, output.Entities[0].ResourceType)
-	assert.Equal(t, description, output.Entities[0].Description)*/
 }

--- a/pkg/repositories/gormimpl/named_entity_repo_test.go
+++ b/pkg/repositories/gormimpl/named_entity_repo_test.go
@@ -158,9 +158,7 @@ func TestListNamedEntity(t *testing.T) {
 	mockQuery := GlobalMock.NewMock()
 
 	mockQuery.WithQuery(
-		`(SELECT project, domain, name FROM "workflows"  WHERE ("workflows"."project" = admintests) AND ` +
-			`("workflows"."domain" = development) GROUP BY project, domain, name ORDER BY name desc LIMIT 20 ` +
-			`OFFSET 0) AS entities`).WithReply(results)
+		`GROUP BY project, domain, name ORDER BY name desc LIMIT 20 OFFSET 0) AS entities`).WithReply(results)
 
 	sortParameter, _ := common.NewSortParameter(admin.Sort{
 		Direction: admin.Sort_DESCENDING,

--- a/pkg/repositories/interfaces/named_entity_repo.go
+++ b/pkg/repositories/interfaces/named_entity_repo.go
@@ -15,6 +15,14 @@ type GetNamedEntityInput struct {
 	Name         string
 }
 
+// Parameters for querying multiple resources.
+type ListNamedEntityInput struct {
+	ListResourceInput
+	Project      string
+	Domain       string
+	ResourceType core.ResourceType
+}
+
 type NamedEntityCollectionOutput struct {
 	Entities []models.NamedEntity
 }
@@ -23,7 +31,7 @@ type NamedEntityCollectionOutput struct {
 type NamedEntityRepoInterface interface {
 	// Returns NamedEntity objects matching the provided query. A limit is
 	// required
-	List(ctx context.Context, resourceType core.ResourceType, input ListResourceInput) (NamedEntityCollectionOutput, error)
+	List(ctx context.Context, input ListNamedEntityInput) (NamedEntityCollectionOutput, error)
 	// Updates NamedEntity record, will create metadata if it does not exist
 	Update(ctx context.Context, input models.NamedEntity) error
 	// Gets metadata (if available) associated with a NamedEntity

--- a/pkg/repositories/mocks/named_entity_metadata_repo.go
+++ b/pkg/repositories/mocks/named_entity_metadata_repo.go
@@ -4,14 +4,12 @@ package mocks
 import (
 	"context"
 
-	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
-
 	"github.com/lyft/flyteadmin/pkg/repositories/interfaces"
 	"github.com/lyft/flyteadmin/pkg/repositories/models"
 )
 
 type GetNamedEntityFunc func(input interfaces.GetNamedEntityInput) (models.NamedEntity, error)
-type ListNamedEntityFunc func(resourceType core.ResourceType, input interfaces.ListResourceInput) (interfaces.NamedEntityCollectionOutput, error)
+type ListNamedEntityFunc func(input interfaces.ListNamedEntityInput) (interfaces.NamedEntityCollectionOutput, error)
 type UpdateNamedEntityFunc func(input models.NamedEntity) error
 
 type MockNamedEntityRepo struct {
@@ -45,9 +43,9 @@ func (r *MockNamedEntityRepo) Get(
 	}, nil
 }
 
-func (r *MockNamedEntityRepo) List(ctx context.Context, resourceType core.ResourceType, input interfaces.ListResourceInput) (interfaces.NamedEntityCollectionOutput, error) {
+func (r *MockNamedEntityRepo) List(ctx context.Context, input interfaces.ListNamedEntityInput) (interfaces.NamedEntityCollectionOutput, error) {
 	if r.listFunction != nil {
-		return r.listFunction(resourceType, input)
+		return r.listFunction(input)
 	}
 	return interfaces.NamedEntityCollectionOutput{}, nil
 }


### PR DESCRIPTION
# TL;DR
Improve LIstNamedEntities performance from **2277.958 ms** to **38.090 ms** in worst case.

Using the postgres query analyzer I observed the existing list named entities database operation can be quite slow, with the majority of the compute time dominated by the GROUP BY, for example using a popular project at lyft:

```
EXPLAIN ANALYZE SELECT workflows.project, workflows.domain, workflows.name, '2' AS resource_type, named_entity_metadata.description, named_entity_metadata.state FROM "workflows" LEFT JOIN named_entity_metadata ON named_entity_metadata.resource_type = 2 AND named_entity_metadata.project = workflows.project AND named_entity_metadata.domain = workflows.domain AND named_entity_metadata.name = workflows.name WHERE (workflows.project = 'priceoptimizeroffline') AND (workflows.domain = 'development') GROUP BY workflows.project, workflows.domain, workflows.name, named_entity_metadata.description, named_entity_metadata.state ORDER BY name asc LIMIT 20 OFFSET 0;
                                                                               QUERY PLAN                                                                                
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=516194.70..516195.44 rows=20 width=611) (actual time=2252.243..2271.214 rows=20 loops=1)
   ->  Group  (cost=516194.70..522699.50 rows=176996 width=611) (actual time=2252.241..2271.207 rows=20 loops=1)
         Group Key: workflows.name, workflows.project, workflows.domain, named_entity_metadata.description, named_entity_metadata.state
         ->  Sort  (cost=516194.70..517278.83 rows=433653 width=579) (actual time=2252.240..2260.633 rows=54460 loops=1)
               Sort Key: workflows.name, named_entity_metadata.description, named_entity_metadata.state
               Sort Method: external sort  Disk: 31192kB
               ->  Merge Left Join  (cost=1.71..250289.38 rows=433653 width=579) (actual time=0.029..322.503 rows=428617 loops=1)
                     Merge Cond: (workflows.name = named_entity_metadata.name)
                     Join Filter: ((named_entity_metadata.project = workflows.project) AND (named_entity_metadata.domain = workflows.domain))
                     ->  Index Only Scan using workflows_pkey on workflows  (cost=0.68..249199.87 rows=433653 width=59) (actual time=0.017..273.702 rows=428617 loops=1)
                           Index Cond: ((project = 'priceoptimizeroffline'::text) AND (domain = 'development'::text))
                           Heap Fetches: 32457
                     ->  Materialize  (cost=1.03..1.03 rows=1 width=616) (actual time=0.011..0.011 rows=0 loops=1)
                           ->  Sort  (cost=1.03..1.03 rows=1 width=616) (actual time=0.008..0.008 rows=0 loops=1)
                                 Sort Key: named_entity_metadata.name
                                 Sort Method: quicksort  Memory: 25kB
                                 ->  Seq Scan on named_entity_metadata  (cost=0.00..1.02 rows=1 width=616) (actual time=0.006..0.006 rows=0 loops=1)
                                       Filter: ((resource_type = 2) AND (project = 'priceoptimizeroffline'::text) AND (domain = 'development'::text))
                                       Rows Removed by Filter: 1
 Planning time: 0.240 ms
 Execution time: 2277.958 ms
```

But moving the GROUP BY to a sub-query improves performance significantly:

``` 
EXPLAIN ANALYZE SELECT entities.project, entities.domain, entities.name, '2' AS resource_type, named_entity_metadata.description, named_entity_metadata.state FROM "named_entity_metadata" RIGHT JOIN (SELECT project, domain, name FROM "workflows"  WHERE ("workflows"."project" = 'priceoptimizeroffline') AND ("workflows"."domain" = 'development') GROUP BY project, domain, name ORDER BY name asc LIMIT 20 OFFSET 0) AS entities ON named_entity_metadata.resource_type = 2 AND named_entity_metadata.project = entities.project AND named_entity_metadata.domain = entities.domain AND named_entity_metadata.name = entities.name  GROUP BY entities.project, entities.domain, entities.name, named_entity_metadata.description, named_entity_metadata.state ORDER BY name asc  ;
                                                                                 QUERY PLAN                                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Group  (cost=30.93..31.23 rows=20 width=611) (actual time=38.041..38.051 rows=20 loops=1)
   Group Key: workflows.name, workflows.project, workflows.domain, named_entity_metadata.description, named_entity_metadata.state
   ->  Sort  (cost=30.93..30.98 rows=20 width=579) (actual time=38.039..38.042 rows=20 loops=1)
         Sort Key: workflows.name, workflows.project, workflows.domain, named_entity_metadata.description, named_entity_metadata.state
         Sort Method: quicksort  Memory: 27kB
         ->  Merge Left Join  (cost=1.70..30.50 rows=20 width=579) (actual time=0.042..38.013 rows=20 loops=1)
               Merge Cond: (workflows.name = named_entity_metadata.name)
               Join Filter: ((named_entity_metadata.project = workflows.project) AND (named_entity_metadata.domain = workflows.domain))
               ->  Limit  (cost=0.68..29.20 rows=20 width=59) (actual time=0.020..37.978 rows=20 loops=1)
                     ->  Group  (cost=0.68..252452.27 rows=176996 width=59) (actual time=0.020..37.973 rows=20 loops=1)
                           Group Key: workflows.name, workflows.project, workflows.domain
                           ->  Index Only Scan using workflows_pkey on workflows  (cost=0.68..249199.87 rows=433653 width=59) (actual time=0.019..31.530 rows=54460 loops=1)
                                 Index Cond: ((project = 'priceoptimizeroffline'::text) AND (domain = 'development'::text))
                                 Heap Fetches: 3930
               ->  Sort  (cost=1.02..1.03 rows=1 width=616) (actual time=0.019..0.021 rows=1 loops=1)
                     Sort Key: named_entity_metadata.name
                     Sort Method: quicksort  Memory: 25kB
                     ->  Seq Scan on named_entity_metadata  (cost=0.00..1.01 rows=1 width=616) (actual time=0.007..0.008 rows=1 loops=1)
                           Filter: (resource_type = 2)
 Planning time: 0.265 ms
 Execution time: 38.090 ms
```

I also saw gains in smaller projects, like flytekit: 8.414 ms vs 0.141 ms

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/lyft/flyte/issues/290

## Follow-up issue
_NA_
