### PR TITLE
Fix value in filter for joins

### DIFF
--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -162,7 +162,7 @@ func (f *inlineFilterImpl) getGormQueryExpr(formattedField string) (GormQueryExp
 
 	// ValueIn is special because it uses repeating values.
 	if f.function == ValueIn {
-		queryStr := fmt.Sprintf(valueInQuery, f.field)
+		queryStr := fmt.Sprintf(valueInQuery, formattedField)
 		return GormQueryExpr{
 			Query: queryStr,
 			Args:  f.repeatedValue,

--- a/pkg/common/filters_test.go
+++ b/pkg/common/filters_test.go
@@ -62,8 +62,14 @@ func TestNewSingleValueCustomizedFilter(t *testing.T) {
 }
 
 func TestNewRepeatedValueFilter(t *testing.T) {
-	_, err := NewRepeatedValueFilter(Workflow, ValueIn, "project", []string{"SuperAwesomeProject", "AnotherAwesomeProject"})
+	vals := []string{"SuperAwesomeProject", "AnotherAwesomeProject"}
+	filter, err := NewRepeatedValueFilter(Workflow, ValueIn, "project", vals)
 	assert.NoError(t, err)
+
+	expression, err := filter.GetGormJoinTableQueryExpr("projects")
+	assert.NoError(t, err)
+	assert.Equal(t, "projects.project in (?)", expression.Query)
+	assert.Equal(t, vals, expression.Args)
 
 	_, err = NewRepeatedValueFilter(Workflow, Equal, "domain", []string{"production", "qa"})
 	assert.EqualError(t, err, "invalid repeated value filter expression: equal")

--- a/tests/task_execution_test.go
+++ b/tests/task_execution_test.go
@@ -283,7 +283,7 @@ func TestCreateAndListTaskExecution(t *testing.T) {
 		NodeExecutionId: nodeExecutionId,
 		Limit:           10,
 		Filters: "eq(task.project, project)+eq(task.domain, development)+eq(task.name, task name)+" +
-			"eq(task.version, task version)+eq(task_execution.retry_attempt, 1)",
+			"eq(task.version, task version)+eq(task_execution.retry_attempt, 1)+value_in(phase, RUNNING)",
 	})
 	assert.Len(t, response.TaskExecutions, 1)
 	assert.Nil(t, err)


### PR DESCRIPTION
# TL;DR
This uses the formatted field for repeated value filters (such as `value_in`) which uses the table name prefix in the case of joins.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
User reported bug.

## Tracking Issue
to be synced

## Follow-up issue
_NA_
