### PR TITLE
Track lineage for child workflows

### DIFF
--- a/pkg/repositories/transformers/execution.go
+++ b/pkg/repositories/transformers/execution.go
@@ -28,6 +28,7 @@ type CreateExecutionModelInput struct {
 	Notifications         []*admin.Notification
 	WorkflowIdentifier    *core.Identifier
 	ParentNodeExecutionID uint
+	SourceExecutionID     uint
 	Cluster               string
 	InputsURI             storage.DataReference
 	UserInputsURI         storage.DataReference
@@ -85,6 +86,7 @@ func CreateExecutionModel(input CreateExecutionModelInput) (*models.Execution, e
 		ExecutionCreatedAt:    &input.CreatedAt,
 		ExecutionUpdatedAt:    &input.CreatedAt,
 		ParentNodeExecutionID: input.ParentNodeExecutionID,
+		SourceExecutionID:     input.SourceExecutionID,
 		Cluster:               input.Cluster,
 		InputsURI:             input.InputsURI,
 		UserInputsURI:         input.UserInputsURI,

--- a/pkg/repositories/transformers/execution_test.go
+++ b/pkg/repositories/transformers/execution_test.go
@@ -82,6 +82,7 @@ func TestCreateExecutionModel(t *testing.T) {
 	assert.EqualValues(t, createdAt, *execution.ExecutionUpdatedAt)
 	assert.Equal(t, int32(admin.ExecutionMetadata_SYSTEM), execution.Mode)
 	assert.Equal(t, nodeID, execution.ParentNodeExecutionID)
+	assert.Equal(t, sourceID, execution.SourceExecutionID)
 	expectedSpec := execRequest.Spec
 	expectedSpec.Metadata.Principal = principal
 	expectedSpec.Metadata.SystemMetadata = &admin.SystemMetadata{

--- a/pkg/repositories/transformers/execution_test.go
+++ b/pkg/repositories/transformers/execution_test.go
@@ -44,6 +44,7 @@ func TestCreateExecutionModel(t *testing.T) {
 	lpID := uint(33)
 	wfID := uint(23)
 	nodeID := uint(11)
+	sourceID := uint(12)
 	createdAt := time.Now()
 	workflowIdentifier := &core.Identifier{
 		Project: "project",
@@ -67,6 +68,7 @@ func TestCreateExecutionModel(t *testing.T) {
 		CreatedAt:             createdAt,
 		WorkflowIdentifier:    workflowIdentifier,
 		ParentNodeExecutionID: nodeID,
+		SourceExecutionID:     sourceID,
 		Principal:             principal,
 		Cluster:               cluster,
 	})


### PR DESCRIPTION
# TL;DR
In addition to recording the parent node execution model id this change also adds the source execution id for relational querying.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description

## Tracking Issue
https://github.com/lyft/flyte/issues/313

## Follow-up issue
_NA_