### PR TITLE
Fix endtoend on master merge

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -45,7 +45,7 @@ jobs:
           kubectl get pods -n kube-system
           echo "current-context:" $(kubectl config current-context)
           echo "environment-kubeconfig:" ${KUBECONFIG}
-          PROPELLER=${{ secrets.flytegithub_repo }}/flyteadmin:${{ github.sha }} make end2end_execute
+          ADMIN=${{ secrets.flytegithub_repo }}/flyteadmin:${{ github.sha }} make end2end_execute
   push-dockerhub:
     runs-on: ubuntu-latest
     needs: bump-version


### PR DESCRIPTION
# TL;DR
Fix github action for master merge to use ADMIN image instead of Propeller image (due to copy paste error)

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [x] Code documentation added
 - [x] Any pending items have an associated Issue

