### PR TITLE
Update async retry mechanisms

### DIFF
--- a/pkg/async/notifications/factory.go
+++ b/pkg/async/notifications/factory.go
@@ -40,8 +40,7 @@ type EmailerConfig struct {
 	BaseURL     string
 }
 
-func GetEmailer(config runtimeInterfaces.NotificationsConfig, scope promutils.Scope,
-	reconnectAttempts int, reconnectDelay time.Duration) interfaces.Emailer {
+func GetEmailer(config runtimeInterfaces.NotificationsConfig, scope promutils.Scope) interfaces.Emailer {
 	switch config.Type {
 	case common.AWS:
 		awsConfig := aws.NewConfig().WithRegion(config.Region).WithMaxRetries(maxRetries)

--- a/pkg/async/notifications/factory.go
+++ b/pkg/async/notifications/factory.go
@@ -45,13 +45,7 @@ func GetEmailer(config runtimeInterfaces.NotificationsConfig, scope promutils.Sc
 	switch config.Type {
 	case common.AWS:
 		awsConfig := aws.NewConfig().WithRegion(config.Region).WithMaxRetries(maxRetries)
-		var awsSession *session.Session
-		var err error
-		err = async.Retry(reconnectAttempts, reconnectDelay, func() error {
-			awsSession, err = session.NewSession(awsConfig)
-			return err
-		})
-
+		awsSession, err := session.NewSession(awsConfig)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/async/notifications/factory.go
+++ b/pkg/async/notifications/factory.go
@@ -2,6 +2,7 @@ package notifications
 
 import (
 	"context"
+	"time"
 
 	"github.com/lyft/flyteadmin/pkg/async/notifications/implementations"
 	"github.com/lyft/flyteadmin/pkg/async/notifications/interfaces"
@@ -59,7 +60,8 @@ func GetEmailer(config runtimeInterfaces.NotificationsConfig, scope promutils.Sc
 	}
 }
 
-func NewNotificationsProcessor(config runtimeInterfaces.NotificationsConfig, scope promutils.Scope) interfaces.Processor {
+func NewNotificationsProcessor(config runtimeInterfaces.NotificationsConfig, scope promutils.Scope,
+	reconnectAttempts int, reconnectDelay time.Duration) interfaces.Processor {
 	var sub pubsub.Subscriber
 	var emailer interfaces.Emailer
 	switch config.Type {
@@ -86,7 +88,7 @@ func NewNotificationsProcessor(config runtimeInterfaces.NotificationsConfig, sco
 			"Using default noop notifications processor implementation for config type [%s]", config.Type)
 		return implementations.NewNoopProcess()
 	}
-	return implementations.NewProcessor(sub, emailer, scope)
+	return implementations.NewProcessor(sub, emailer, scope, reconnectAttempts, reconnectDelay)
 }
 
 func NewNotificationsPublisher(config runtimeInterfaces.NotificationsConfig, scope promutils.Scope) interfaces.Publisher {

--- a/pkg/async/notifications/factory.go
+++ b/pkg/async/notifications/factory.go
@@ -87,7 +87,7 @@ func NewNotificationsProcessor(config runtimeInterfaces.NotificationsConfig, sco
 		if err != nil {
 			panic(err)
 		}
-		emailer = GetEmailer(config, scope, reconnectAttempts, reconnectDelay)
+		emailer = GetEmailer(config, scope)
 	case common.Local:
 		fallthrough
 	default:

--- a/pkg/async/notifications/implementations/noop_notifications.go
+++ b/pkg/async/notifications/implementations/noop_notifications.go
@@ -39,9 +39,8 @@ func NewNoopPublish() interfaces.Publisher {
 
 type NoopProcess struct{}
 
-func (n *NoopProcess) StartProcessing() error {
+func (n *NoopProcess) StartProcessing() {
 	logger.Debug(context.Background(), "call to noop start processing.")
-	return nil
 }
 
 func (n *NoopProcess) StopProcessing() error {

--- a/pkg/async/notifications/implementations/processor.go
+++ b/pkg/async/notifications/implementations/processor.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/lyft/flyteadmin/pkg/async"
+
 	"github.com/lyft/flyteadmin/pkg/async/notifications/interfaces"
 
 	"encoding/base64"
@@ -31,26 +33,23 @@ type processorSystemMetrics struct {
 
 // TODO: Add a counter that encompasses the publisher stats grouped by project and domain.
 type Processor struct {
-	sub               pubsub.Subscriber
-	email             interfaces.Emailer
-	systemMetrics     processorSystemMetrics
-	reconnectAttempts int
-	reconnectDelay    time.Duration
-}
-
-func (p *Processor) StartProcessing() {
-	for reconnectAttempt := 0; reconnectAttempt <= p.reconnectAttempts; reconnectAttempt++ {
-		err := p.run()
-		logger.Errorf(context.Background(), "error with running processor err: [%v] ", err)
-		time.Sleep(p.reconnectDelay)
-		logger.Warningf(context.Background(),
-			"Restarting notifications processor, attempt %d of %d", reconnectAttempt, p.reconnectAttempts)
-	}
+	sub           pubsub.Subscriber
+	email         interfaces.Emailer
+	systemMetrics processorSystemMetrics
 }
 
 // Currently only email is the supported notification because slack and pagerduty both use
 // email client to trigger those notifications.
 // When Pagerduty and other notifications are supported, a publisher per type should be created.
+func (p *Processor) StartProcessing() {
+	for {
+		logger.Warningf(context.Background(), "Starting notifications processor")
+		err := p.run()
+		logger.Errorf(context.Background(), "error with running processor err: [%v] ", err)
+		time.Sleep(async.RetryDelay)
+	}
+}
+
 func (p *Processor) run() error {
 	var emailMessage admin.EmailMessage
 	var err error
@@ -164,13 +163,10 @@ func newProcessorSystemMetrics(scope promutils.Scope) processorSystemMetrics {
 	}
 }
 
-func NewProcessor(sub pubsub.Subscriber, emailer interfaces.Emailer, scope promutils.Scope,
-	reconnectAttempts int, reconnectDelay time.Duration) interfaces.Processor {
+func NewProcessor(sub pubsub.Subscriber, emailer interfaces.Emailer, scope promutils.Scope) interfaces.Processor {
 	return &Processor{
-		sub:               sub,
-		email:             emailer,
-		systemMetrics:     newProcessorSystemMetrics(scope.NewSubScope("processor")),
-		reconnectAttempts: reconnectAttempts,
-		reconnectDelay:    reconnectDelay,
+		sub:           sub,
+		email:         emailer,
+		systemMetrics: newProcessorSystemMetrics(scope.NewSubScope("processor")),
 	}
 }

--- a/pkg/async/notifications/implementations/processor_test.go
+++ b/pkg/async/notifications/implementations/processor_test.go
@@ -41,13 +41,13 @@ func TestProcessor_StartProcessing(t *testing.T) {
 	mockEmailer.SetSendEmailFunc(sendEmailValidationFunc)
 	// TODO Add test for metric inc for number of messages processed.
 	// Assert 1 message processed and 1 total.
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 }
 
 func TestProcessor_StartProcessingNoMessages(t *testing.T) {
 	initializeProcessor()
 	// Expect no errors are returned.
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 	// TODO add test for metric inc() for number of messages processed.
 	// Assert 0 messages processed and 0 total.
 }
@@ -59,7 +59,7 @@ func TestProcessor_StartProcessingNoNotificationMessage(t *testing.T) {
 	}
 	initializeProcessor()
 	testSubscriber.JSONMessages = append(testSubscriber.JSONMessages, testMessage)
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 	// TODO add test for metric inc() for number of messages processed.
 	// Assert 1 messages error and 1 total.
 }
@@ -72,7 +72,7 @@ func TestProcessor_StartProcessingMessageWrongDataType(t *testing.T) {
 	}
 	initializeProcessor()
 	testSubscriber.JSONMessages = append(testSubscriber.JSONMessages, testMessage)
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 	// TODO add test for metric inc() for number of messages processed.
 	// Assert 1 messages error and 1 total.
 }
@@ -85,7 +85,7 @@ func TestProcessor_StartProcessingBase64DecodeError(t *testing.T) {
 	}
 	initializeProcessor()
 	testSubscriber.JSONMessages = append(testSubscriber.JSONMessages, testMessage)
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 	// TODO add test for metric inc() for number of messages processed.
 	// Assert 1 messages error and 1 total.
 }
@@ -99,7 +99,7 @@ func TestProcessor_StartProcessingProtoMarshallError(t *testing.T) {
 	}
 	initializeProcessor()
 	testSubscriber.JSONMessages = append(testSubscriber.JSONMessages, testMessage)
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 	// TODO add test for metric inc() for number of messages processed.
 	// Assert 1 messages error and 1 total.
 }
@@ -110,7 +110,7 @@ func TestProcessor_StartProcessingError(t *testing.T) {
 	// The error set by GivenErrError is returned by Err().
 	// Err() is checked before Run() returning.
 	testSubscriber.GivenErrError = ret
-	assert.Equal(t, ret, testProcessor.StartProcessing())
+	assert.Equal(t, ret, testProcessor.(*Processor).run())
 }
 
 func TestProcessor_StartProcessingEmailError(t *testing.T) {
@@ -124,7 +124,7 @@ func TestProcessor_StartProcessingEmailError(t *testing.T) {
 
 	// Even if there is an error in sending an email StartProcessing will return no errors.
 	// TODO: Once stats have been added check for an email error stat.
-	assert.Nil(t, testProcessor.StartProcessing())
+	assert.Nil(t, testProcessor.(*Processor).run())
 }
 
 func TestProcessor_StopProcessing(t *testing.T) {

--- a/pkg/async/notifications/implementations/publisher_test.go
+++ b/pkg/async/notifications/implementations/publisher_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/lyft/flyteadmin/pkg/async/notifications/mocks"
 
@@ -49,11 +48,7 @@ var testSubscriberMessage = map[string]interface{}{
 var testSubscriber pubsubtest.TestSubscriber
 var mockSub pubsub.Subscriber = &testSubscriber
 var mockEmail mocks.MockEmailer
-
-const retryAttempts = 3
-
-var retryDelay = time.Minute
-var testProcessor = NewProcessor(mockSub, &mockEmail, promutils.NewTestScope(), retryAttempts, retryDelay)
+var testProcessor = NewProcessor(mockSub, &mockEmail, promutils.NewTestScope())
 
 // This method should be invoked before every test around Publisher.
 func initializePublisher() {

--- a/pkg/async/notifications/implementations/publisher_test.go
+++ b/pkg/async/notifications/implementations/publisher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/lyft/flyteadmin/pkg/async/notifications/mocks"
 
@@ -48,7 +49,11 @@ var testSubscriberMessage = map[string]interface{}{
 var testSubscriber pubsubtest.TestSubscriber
 var mockSub pubsub.Subscriber = &testSubscriber
 var mockEmail mocks.MockEmailer
-var testProcessor = NewProcessor(mockSub, &mockEmail, promutils.NewTestScope())
+
+const retryAttempts = 3
+
+var retryDelay = time.Minute
+var testProcessor = NewProcessor(mockSub, &mockEmail, promutils.NewTestScope(), retryAttempts, retryDelay)
 
 // This method should be invoked before every test around Publisher.
 func initializePublisher() {

--- a/pkg/async/notifications/interfaces/processor.go
+++ b/pkg/async/notifications/interfaces/processor.go
@@ -8,7 +8,7 @@ type Processor interface {
 	// If the channel closes gracefully, no error will be returned.
 	// If the underlying channel experiences errors,
 	// an error is returned and the channel is closed.
-	StartProcessing() error
+	StartProcessing()
 
 	// This should be invoked when the application is shutting down.
 	// If StartProcessing() returned an error, StopProcessing() will return an error because

--- a/pkg/async/schedule/aws/workflow_executor.go
+++ b/pkg/async/schedule/aws/workflow_executor.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lyft/flyteadmin/pkg/async"
+	runtimeInterfaces "github.com/lyft/flyteadmin/pkg/runtime/interfaces"
+
 	"github.com/lyft/flytestdlib/contextutils"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
@@ -168,6 +171,15 @@ func (e *workflowExecutor) formulateExecutionCreateRequest(
 }
 
 func (e *workflowExecutor) Run() {
+	for {
+		logger.Warningf(context.Background(), "Starting workflow executor")
+		err := e.run()
+		logger.Errorf(context.Background(), "error with workflow executor err: [%v] ", err)
+		time.Sleep(async.RetryDelay)
+	}
+}
+
+func (e *workflowExecutor) run() error {
 	for message := range e.subscriber.Start() {
 		scheduledWorkflowExecutionRequest, err := DeserializeScheduleWorkflowPayload(message.Message())
 		ctx := context.Background()
@@ -244,6 +256,7 @@ func (e *workflowExecutor) Run() {
 	}
 	err := e.subscriber.Err()
 	logger.Errorf(context.TODO(), "Gizmo subscriber closed channel with err: [%+v]", err)
+	return err
 }
 
 func (e *workflowExecutor) Stop() error {
@@ -290,14 +303,23 @@ func newWorkflowExecutorMetrics(scope promutils.Scope) workflowExecutorMetrics {
 }
 
 func NewWorkflowExecutor(
-	config aws.SQSConfig, executionManager interfaces.ExecutionInterface,
+	config aws.SQSConfig, schedulerConfig runtimeInterfaces.SchedulerConfig, executionManager interfaces.ExecutionInterface,
 	launchPlanManager interfaces.LaunchPlanInterface, scope promutils.Scope) scheduleInterfaces.WorkflowExecutor {
 
 	config.TimeoutSeconds = &timeout
 	// By default gizmo tries to base64 decode messages. Since we don't use the gizmo publisher interface to publish
 	// messages these are not encoded in base64 by default. Disable this behavior.
 	config.ConsumeBase64 = &doNotconsumeBase64
-	subscriber, err := aws.NewSubscriber(config)
+
+	maxReconnectAttempts := schedulerConfig.ReconnectAttempts
+	reconnectDelay := time.Duration(schedulerConfig.ReconnectDelaySeconds) * time.Second
+	var subscriber pubsub.Subscriber
+	var err error
+	err = async.Retry(maxReconnectAttempts, reconnectDelay, func() error {
+		subscriber, err = aws.NewSubscriber(config)
+		return err
+	})
+
 	if err != nil {
 		scope.MustNewCounter(
 			"initialize_executor_failed", "failures initializing scheduled workflow executor").Inc()

--- a/pkg/async/schedule/aws/workflow_executor_test.go
+++ b/pkg/async/schedule/aws/workflow_executor_test.go
@@ -283,8 +283,9 @@ func TestRun(t *testing.T) {
 			}, nil
 		})
 	testExecutor := newWorkflowExecutorForTest(&testSubscriber, &testExecutionManager, launchPlanManager)
-	testExecutor.Run()
+	err := testExecutor.run()
 	assert.Len(t, messages, messagesSeen)
+	assert.Nil(t, err)
 }
 
 func TestStop(t *testing.T) {

--- a/pkg/async/shared.go
+++ b/pkg/async/shared.go
@@ -8,7 +8,7 @@ import (
 )
 
 // RetryDelay indicates how long to wait between restarting a subscriber connection in the case of network failures.
-var RetryDelay = 30 * time.Minute
+var RetryDelay = 30 * time.Second
 
 func Retry(attempts int, delay time.Duration, f func() error) error {
 	var err error

--- a/pkg/async/shared.go
+++ b/pkg/async/shared.go
@@ -1,0 +1,25 @@
+package async
+
+import (
+	"context"
+	"time"
+
+	"github.com/lyft/flytestdlib/logger"
+)
+
+// RetryDelay indicates how long to wait between restarting a subscriber connection in the case of network failures.
+var RetryDelay = 30 * time.Minute
+
+func Retry(attempts int, delay time.Duration, f func() error) error {
+	var err error
+	for attempt := 0; attempt <= attempts; attempt++ {
+		err = f()
+		if err == nil {
+			return nil
+		}
+		logger.Warningf(context.Background(),
+			"Failed [%v] on attempt %d of %d", err, attempt, attempts)
+		time.Sleep(delay)
+	}
+	return err
+}

--- a/pkg/async/shared_test.go
+++ b/pkg/async/shared_test.go
@@ -1,0 +1,33 @@
+package async
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetry(t *testing.T) {
+	attemptsRecorded := 0
+	err := Retry(3, time.Millisecond, func() error {
+		if attemptsRecorded == 3 {
+			return nil
+		}
+		attemptsRecorded++
+		return errors.New("foo")
+	})
+	assert.Nil(t, err)
+}
+
+func TestRetry_RetriesExhausted(t *testing.T) {
+	attemptsRecorded := 0
+	err := Retry(2, time.Millisecond, func() error {
+		if attemptsRecorded == 3 {
+			return nil
+		}
+		attemptsRecorded++
+		return errors.New("foo")
+	})
+	assert.EqualError(t, err, "foo")
+}

--- a/pkg/rpc/adminservice/base.go
+++ b/pkg/rpc/adminservice/base.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"runtime/debug"
-	"time"
 
 	"github.com/lyft/flyteadmin/pkg/manager/impl/resources"
 
@@ -96,10 +95,7 @@ func NewAdminServer(kubeConfig, master string) *AdminService {
 	}
 
 	publisher := notifications.NewNotificationsPublisher(*configuration.ApplicationConfiguration().GetNotificationsConfig(), adminScope)
-	processor := notifications.NewNotificationsProcessor(*configuration.ApplicationConfiguration().GetNotificationsConfig(), adminScope,
-		configuration.ApplicationConfiguration().GetNotificationsConfig().ReconnectAttempts,
-		time.Duration(configuration.ApplicationConfiguration().GetNotificationsConfig().
-			ReconnectDelaySeconds)*time.Second)
+	processor := notifications.NewNotificationsProcessor(*configuration.ApplicationConfiguration().GetNotificationsConfig(), adminScope)
 	go func() {
 		logger.Info(context.Background(), "Started processing notifications.")
 		processor.StartProcessing()
@@ -108,10 +104,9 @@ func NewAdminServer(kubeConfig, master string) *AdminService {
 	// Configure workflow scheduler async processes.
 	schedulerConfig := configuration.ApplicationConfiguration().GetSchedulerConfig()
 	workflowScheduler := schedule.NewWorkflowScheduler(schedule.WorkflowSchedulerConfig{
-		Retries:                defaultRetries,
-		EventSchedulerConfig:   schedulerConfig.EventSchedulerConfig,
-		WorkflowExecutorConfig: schedulerConfig.WorkflowExecutorConfig,
-		Scope:                  adminScope,
+		Retries:         defaultRetries,
+		SchedulerConfig: *schedulerConfig,
+		Scope:           adminScope,
 	})
 
 	eventScheduler := workflowScheduler.GetEventScheduler()
@@ -142,17 +137,6 @@ func NewAdminServer(kubeConfig, master string) *AdminService {
 	go func() {
 		logger.Info(context.Background(), "Starting the scheduled workflow executor")
 		scheduledWorkflowExecutor.Run()
-
-		maxReconnectAttempts := configuration.ApplicationConfiguration().GetSchedulerConfig().
-			WorkflowExecutorConfig.ReconnectAttempts
-		reconnectDelay := time.Duration(configuration.ApplicationConfiguration().GetSchedulerConfig().
-			WorkflowExecutorConfig.ReconnectDelaySeconds) * time.Second
-		for reconnectAttempt := 0; reconnectAttempt < maxReconnectAttempts; reconnectAttempt++ {
-			time.Sleep(reconnectDelay)
-			logger.Warningf(context.Background(),
-				"Restarting scheduled workflow executor, attempt %d of %d", reconnectAttempt, maxReconnectAttempts)
-			scheduledWorkflowExecutor.Run()
-		}
 	}()
 
 	// Serve profiling endpoints.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -149,6 +149,10 @@ type NotificationsConfig struct {
 	NotificationsPublisherConfig NotificationsPublisherConfig `json:"publisher"`
 	NotificationsProcessorConfig NotificationsProcessorConfig `json:"processor"`
 	NotificationsEmailerConfig   NotificationsEmailerConfig   `json:"emailer"`
+	// Number of times to attempt recreating a notifications processor client should there be any disruptions.
+	ReconnectAttempts int `json:"reconnectAttempts"`
+	// Specifies the time interval to wait before attempting to reconnect the notifications processor client.
+	ReconnectDelaySeconds int `json:"reconnectDelaySeconds"`
 }
 
 // Domains are always globally set in the application config, whereas individual projects can be individually registered.

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -84,16 +84,16 @@ type WorkflowExecutorConfig struct {
 	// The account id (according to whichever cloud provider scheme is used) that has permission to read from the above
 	// queue.
 	AccountID string `json:"accountId"`
-	// Specifies the number of times to attempt recreating a workflow executor client should there be any disruptions.
-	ReconnectAttempts int `json:"reconnectAttempts"`
-	// Specifies the time interval to wait before attempting to reconnect the workflow executor client.
-	ReconnectDelaySeconds int `json:"reconnectDelaySeconds"`
 }
 
 // This configuration is the base configuration for all scheduler-related set-up.
 type SchedulerConfig struct {
 	EventSchedulerConfig   EventSchedulerConfig   `json:"eventScheduler"`
 	WorkflowExecutorConfig WorkflowExecutorConfig `json:"workflowExecutor"`
+	// Specifies the number of times to attempt recreating a workflow executor client should there be any disruptions.
+	ReconnectAttempts int `json:"reconnectAttempts"`
+	// Specifies the time interval to wait before attempting to reconnect the workflow executor client.
+	ReconnectDelaySeconds int `json:"reconnectDelaySeconds"`
 }
 
 // Configuration specific to setting up signed urls.


### PR DESCRIPTION
# TL;DR
Add retries to notifications processor to handle underlying SQS connection failures.

In general, add user-config specified retries for initializing the initial AWS/GCP client but otherwise indefinitely retry in the case an open channel hiccups.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/376

## Follow-up issue
_NA_