### PR TITLE
Admin changes for Parent child node execution relationship

### DIFF
--- a/pkg/manager/impl/node_execution_manager.go
+++ b/pkg/manager/impl/node_execution_manager.go
@@ -54,10 +54,9 @@ const (
 	alreadyInTerminalStatus
 )
 
-const addIsParentFilter = true
-
 var isParent = common.NewMapFilter(map[string]interface{}{
 	shared.ParentTaskExecutionID: nil,
+	shared.ParentID:              nil,
 })
 
 func getNodeExecutionContext(ctx context.Context, identifier *core.NodeExecutionIdentifier) context.Context {
@@ -77,9 +76,21 @@ func (m *NodeExecutionManager) createNodeExecutionWithEvent(
 		}
 		parentTaskExecutionID = taskExecutionModel.ID
 	}
+	var parentID *uint
+	if request.Event.ParentNodeMetadata != nil {
+		parentNodeExecutionModel, err := util.GetNodeExecutionModel(ctx, m.db, &core.NodeExecutionIdentifier{
+			ExecutionId: request.Event.Id.ExecutionId,
+			NodeId:      request.Event.ParentNodeMetadata.NodeId,
+		})
+		if err != nil {
+			return err
+		}
+		parentID = &parentNodeExecutionModel.ID
+	}
 	nodeExecutionModel, err := transformers.CreateNodeExecutionModel(transformers.ToNodeExecutionModelInput{
 		Request:               request,
 		ParentTaskExecutionID: parentTaskExecutionID,
+		ParentID:              parentID,
 	})
 	if err != nil {
 		logger.Debugf(ctx, "failed to create node execution model for event request: %s with err: %v",
@@ -237,7 +248,7 @@ func (m *NodeExecutionManager) GetNodeExecution(
 
 func (m *NodeExecutionManager) listNodeExecutions(
 	ctx context.Context, identifierFilters []common.InlineFilter,
-	requestFilters string, limit uint32, requestToken string, sortBy *admin.Sort, addIsParentFilter bool) (
+	requestFilters string, limit uint32, requestToken string, sortBy *admin.Sort, mapFilters []common.MapFilter) (
 	*admin.NodeExecutionList, error) {
 
 	filters, err := util.AddRequestFilters(requestFilters, common.NodeExecution, identifierFilters)
@@ -262,11 +273,8 @@ func (m *NodeExecutionManager) listNodeExecutions(
 		InlineFilters: filters,
 		SortParameter: sortParameter,
 	}
-	if addIsParentFilter {
-		listInput.MapFilters = []common.MapFilter{
-			isParent,
-		}
-	}
+
+	listInput.MapFilters = mapFilters
 	output, err := m.db.NodeExecutionRepo().List(ctx, listInput)
 	if err != nil {
 		logger.Debugf(ctx, "Failed to list node executions for request with err %v", err)
@@ -301,8 +309,28 @@ func (m *NodeExecutionManager) ListNodeExecutions(
 	if err != nil {
 		return nil, err
 	}
+	var mapFilters []common.MapFilter
+	if request.UniqueParentId != "" {
+		parentNodeExecution, err := util.GetNodeExecutionModel(ctx, m.db, &core.NodeExecutionIdentifier{
+			ExecutionId: request.WorkflowExecutionId,
+			NodeId:      request.UniqueParentId,
+		})
+		if err != nil {
+			return nil, err
+		}
+		parentIDFilter, err := common.NewSingleValueFilter(
+			common.NodeExecution, common.Equal, shared.ParentID, parentNodeExecution.ID)
+		if err != nil {
+			return nil, err
+		}
+		identifierFilters = append(identifierFilters, parentIDFilter)
+	} else {
+		mapFilters = []common.MapFilter{
+			isParent,
+		}
+	}
 	return m.listNodeExecutions(
-		ctx, identifierFilters, request.Filters, request.Limit, request.Token, request.SortBy, addIsParentFilter)
+		ctx, identifierFilters, request.Filters, request.Limit, request.Token, request.SortBy, mapFilters)
 }
 
 // Filters on node executions matching the execution parameters (execution project, domain, and name) as well as the
@@ -330,7 +358,7 @@ func (m *NodeExecutionManager) ListNodeExecutionsForTask(
 	}
 	identifierFilters = append(identifierFilters, nodeIDFilter)
 	return m.listNodeExecutions(
-		ctx, identifierFilters, request.Filters, request.Limit, request.Token, request.SortBy, !addIsParentFilter)
+		ctx, identifierFilters, request.Filters, request.Limit, request.Token, request.SortBy, nil)
 }
 
 func (m *NodeExecutionManager) GetNodeExecutionData(

--- a/pkg/manager/impl/node_execution_manager.go
+++ b/pkg/manager/impl/node_execution_manager.go
@@ -83,6 +83,8 @@ func (m *NodeExecutionManager) createNodeExecutionWithEvent(
 			NodeId:      request.Event.ParentNodeMetadata.NodeId,
 		})
 		if err != nil {
+			logger.Errorf(ctx, "failed to fetch node execution for the parent node: %v %s with err",
+				request.Event.Id.ExecutionId, request.Event.ParentNodeMetadata.NodeId, err)
 			return err
 		}
 		parentID = &parentNodeExecutionModel.ID

--- a/pkg/manager/impl/shared/constants.go
+++ b/pkg/manager/impl/shared/constants.go
@@ -35,4 +35,6 @@ const (
 	Attributes            = "attributes"
 	MatchingAttributes    = "matching_attributes"
 	Resourcetype          = "resource_type"
+	// Parent of a node execution in the node executions table
+	ParentID = "parent_id"
 )

--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -233,4 +233,14 @@ var Migrations = []*gormigrate.Migration{
 			return tx.Model(&models.NodeExecution{}).DropColumn("cache_status").Error
 		},
 	},
+
+	{
+		ID: "2020-07-31-node-execution",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&models.NodeExecution{}).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Model(&models.NodeExecution{}).DropColumn("parent_id").DropColumn("node_execution_metadata").Error
+		},
+	},
 }

--- a/pkg/repositories/gormimpl/node_execution_repo.go
+++ b/pkg/repositories/gormimpl/node_execution_repo.go
@@ -56,7 +56,7 @@ func (r *NodeExecutionRepo) Get(ctx context.Context, input interfaces.GetNodeExe
 				Name:    input.NodeExecutionIdentifier.ExecutionId.Name,
 			},
 		},
-	}).First(&nodeExecution)
+	}).Preload("ChildNodeExecutions").First(&nodeExecution)
 	timer.Stop()
 	if tx.Error != nil {
 		return models.NodeExecution{}, r.errorTransformer.ToFlyteAdminError(tx.Error)
@@ -103,7 +103,7 @@ func (r *NodeExecutionRepo) List(ctx context.Context, input interfaces.ListResou
 		return interfaces.NodeExecutionCollectionOutput{}, err
 	}
 	var nodeExecutions []models.NodeExecution
-	tx := r.db.Limit(input.Limit).Offset(input.Offset)
+	tx := r.db.Limit(input.Limit).Offset(input.Offset).Preload("ChildNodeExecutions")
 	// And add join condition (joining multiple tables is fine even we only filter on a subset of table attributes).
 	// (this query isn't called for deletes).
 	tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.execution_project = %s.execution_project AND "+

--- a/pkg/repositories/models/node_execution.go
+++ b/pkg/repositories/models/node_execution.go
@@ -36,6 +36,7 @@ type NodeExecution struct {
 	// List of child node executions - for cases like Dynamic task, sub workflow, etc
 	ChildNodeExecutions []NodeExecution `gorm:"foreignkey:ParentID"`
 	// The task execution (if any) which launched this node execution.
+	// TO BE DEPRECATED - as we have now introduced ParentID
 	ParentTaskExecutionID uint `sql:"default:null" gorm:"index"`
 	// The workflow execution (if any) which this node execution launched
 	// NOTE: LaunchedExecution[foreignkey:ParentNodeExecutionID] refers to Workflow execution launched and is different from ParentID

--- a/pkg/repositories/models/node_execution.go
+++ b/pkg/repositories/models/node_execution.go
@@ -29,9 +29,16 @@ type NodeExecution struct {
 	NodeExecutionUpdatedAt *time.Time
 	Duration               time.Duration
 	NodeExecutionEvents    []NodeExecutionEvent
+	// Metadata about the node execution.
+	NodeExecutionMetadata []byte
+	// Parent that spawned this node execution - value is empty for executions at level 0
+	ParentID *uint `sql:"default:null"`
+	// List of child node executions - for cases like Dynamic task, sub workflow, etc
+	ChildNodeExecutions []NodeExecution `gorm:"foreignkey:ParentID"`
 	// The task execution (if any) which launched this node execution.
 	ParentTaskExecutionID uint `sql:"default:null" gorm:"index"`
 	// The workflow execution (if any) which this node execution launched
+	// NOTE: LaunchedExecution[foreignkey:ParentNodeExecutionID] refers to Workflow execution launched and is different from ParentID
 	LaunchedExecution Execution `gorm:"foreignkey:ParentNodeExecutionID"`
 	// Execution Error Kind. nullable, can be one of core.ExecutionError_ErrorKind
 	ErrorKind *string `gorm:"index"`

--- a/pkg/repositories/transformers/node_execution_test.go
+++ b/pkg/repositories/transformers/node_execution_test.go
@@ -340,11 +340,11 @@ func TestFromNodeExecutionModels(t *testing.T) {
 					Name:    "name",
 				},
 			},
-			Phase:    "NodeExecutionPhase_NODE_PHASE_RUNNING",
-			Closure:  closureBytes,
+			Phase:                 "NodeExecutionPhase_NODE_PHASE_RUNNING",
+			Closure:               closureBytes,
 			NodeExecutionMetadata: nodeExecutionMetadataBytes,
-			InputURI: "input uri",
-			Duration: duration,
+			InputURI:              "input uri",
+			Duration:              duration,
 		},
 	})
 	assert.Nil(t, err)

--- a/pkg/repositories/transformers/node_execution_test.go
+++ b/pkg/repositories/transformers/node_execution_test.go
@@ -27,6 +27,12 @@ var closure = &admin.NodeExecutionClosure{
 	Duration:  ptypes.DurationProto(duration),
 }
 var closureBytes, _ = proto.Marshal(closure)
+var nodeExecutionMetadata = admin.NodeExecutionMetaData{
+	IsParentNode: false,
+	RetryGroup:   "r",
+	SpecNodeId:   "sp",
+}
+var nodeExecutionMetadataBytes, _ = proto.Marshal(&nodeExecutionMetadata)
 
 var childExecutionID = &core.WorkflowExecutionIdentifier{
 	Project: "p",
@@ -154,6 +160,7 @@ func TestCreateNodeExecutionModel(t *testing.T) {
 		StartedAt:              &occurredAt,
 		NodeExecutionCreatedAt: &occurredAt,
 		NodeExecutionUpdatedAt: &occurredAt,
+		NodeExecutionMetadata:  []byte{},
 		ParentTaskExecutionID:  8,
 	}, nodeExecutionModel)
 }
@@ -260,8 +267,52 @@ func TestFromNodeExecutionModel(t *testing.T) {
 				Name:    "name",
 			},
 		},
-		Phase:    "NodeExecutionPhase_NODE_PHASE_RUNNING",
-		Closure:  closureBytes,
+		Phase:                 "NodeExecutionPhase_NODE_PHASE_RUNNING",
+		Closure:               closureBytes,
+		NodeExecutionMetadata: nodeExecutionMetadataBytes,
+		InputURI:              "input uri",
+		Duration:              duration,
+	})
+	assert.Nil(t, err)
+	assert.True(t, proto.Equal(&admin.NodeExecution{
+		Id:       &nodeExecutionIdentifier,
+		InputUri: "input uri",
+		Closure:  closure,
+		Metadata: &nodeExecutionMetadata,
+	}, nodeExecution))
+}
+
+func TestFromNodeExecutionModelWithChildren(t *testing.T) {
+	nodeExecutionIdentifier := core.NodeExecutionIdentifier{
+		NodeId: "nodey",
+		ExecutionId: &core.WorkflowExecutionIdentifier{
+			Project: "project",
+			Domain:  "domain",
+			Name:    "name",
+		},
+	}
+	nodeExecution, err := FromNodeExecutionModel(models.NodeExecution{
+		NodeExecutionKey: models.NodeExecutionKey{
+			NodeID: "nodey",
+			ExecutionKey: models.ExecutionKey{
+				Project: "project",
+				Domain:  "domain",
+				Name:    "name",
+			},
+		},
+		Phase:                 "NodeExecutionPhase_NODE_PHASE_RUNNING",
+		Closure:               closureBytes,
+		NodeExecutionMetadata: nodeExecutionMetadataBytes,
+		ChildNodeExecutions: []models.NodeExecution{
+			{NodeExecutionKey: models.NodeExecutionKey{
+				NodeID: "nodec1",
+				ExecutionKey: models.ExecutionKey{
+					Project: "project",
+					Domain:  "domain",
+					Name:    "name",
+				},
+			}},
+		},
 		InputURI: "input uri",
 		Duration: duration,
 	})
@@ -270,6 +321,11 @@ func TestFromNodeExecutionModel(t *testing.T) {
 		Id:       &nodeExecutionIdentifier,
 		InputUri: "input uri",
 		Closure:  closure,
+		Metadata: &admin.NodeExecutionMetaData{
+			IsParentNode: true,
+			RetryGroup:   "r",
+			SpecNodeId:   "sp",
+		},
 	}, nodeExecution))
 }
 
@@ -286,6 +342,7 @@ func TestFromNodeExecutionModels(t *testing.T) {
 			},
 			Phase:    "NodeExecutionPhase_NODE_PHASE_RUNNING",
 			Closure:  closureBytes,
+			NodeExecutionMetadata: nodeExecutionMetadataBytes,
 			InputURI: "input uri",
 			Duration: duration,
 		},
@@ -303,5 +360,6 @@ func TestFromNodeExecutionModels(t *testing.T) {
 		},
 		InputUri: "input uri",
 		Closure:  closure,
+		Metadata: &nodeExecutionMetadata,
 	}, nodeExecutions[0]))
 }


### PR DESCRIPTION
This PR has the following
- Ability to accept metadata in NodeExecution event - spec_node_id, parent_id, and retry group.
- DB changes to store the extra information.
- DB changes to support parent child node execution relationship
- Changes to expose and query node executions at root or for a parent.
- Unit and end2end integration tests.

 
## Type
 - [ ] Bug Fix
 - [X] Feature
 - [ ] Plugin

## Are all requirements met?

 - [X] Code completed
 - [X] Smoke tested
 - [X] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue


## Tracking Issue
https://github.com/lyft/flyte/issues/218
