### PR TITLE
Add Parent_id index for Admin database

### DIFF
--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -233,9 +233,17 @@ var Migrations = []*gormigrate.Migration{
 			return tx.Model(&models.NodeExecution{}).DropColumn("cache_status").Error
 		},
 	},
-
 	{
 		ID: "2020-07-31-node-execution",
+		Migrate: func(tx *gorm.DB) error {
+			return tx.AutoMigrate(&models.NodeExecution{}).Error
+		},
+		Rollback: func(tx *gorm.DB) error {
+			return tx.Model(&models.NodeExecution{}).DropColumn("parent_id").DropColumn("node_execution_metadata").Error
+		},
+	},
+	{
+		ID: "2020-08-13-node-execution",
 		Migrate: func(tx *gorm.DB) error {
 			return tx.AutoMigrate(&models.NodeExecution{}).Error
 		},

--- a/pkg/repositories/models/node_execution.go
+++ b/pkg/repositories/models/node_execution.go
@@ -32,7 +32,7 @@ type NodeExecution struct {
 	// Metadata about the node execution.
 	NodeExecutionMetadata []byte
 	// Parent that spawned this node execution - value is empty for executions at level 0
-	ParentID *uint `sql:"default:null"`
+	ParentID *uint `sql:"default:null" gorm:"index"`
 	// List of child node executions - for cases like Dynamic task, sub workflow, etc
 	ChildNodeExecutions []NodeExecution `gorm:"foreignkey:ParentID"`
 	// The task execution (if any) which launched this node execution.

--- a/tests/node_execution_test.go
+++ b/tests/node_execution_test.go
@@ -347,7 +347,7 @@ func TestListNodeExecutionWithParent(t *testing.T) {
 	assert.Len(t, response.NodeExecutions, 2)
 	nodeExecutionResponse = response.NodeExecutions[0]
 	assert.True(t, proto.Equal(&core.NodeExecutionIdentifier{
-		NodeId:      "child",
+		NodeId:      "child2",
 		ExecutionId: nodeExecutionId.ExecutionId,
 	}, nodeExecutionResponse.Id))
 	assert.Equal(t, core.NodeExecution_RUNNING, nodeExecutionResponse.Closure.Phase)
@@ -356,7 +356,7 @@ func TestListNodeExecutionWithParent(t *testing.T) {
 
 	nodeExecutionResponse = response.NodeExecutions[1]
 	assert.True(t, proto.Equal(&core.NodeExecutionIdentifier{
-		NodeId:      "child2",
+		NodeId:      "child",
 		ExecutionId: nodeExecutionId.ExecutionId,
 	}, nodeExecutionResponse.Id))
 	assert.Equal(t, core.NodeExecution_RUNNING, nodeExecutionResponse.Closure.Phase)


### PR DESCRIPTION
Parent_ID column is missing an index in node_executions table.

# TL;DR
_Please replace this text with a description of what this PR accomplishes._

## Type
 - [X] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [X] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue
