### PR TITLE
Allow random cluster selection when no override

### DIFF
--- a/pkg/executioncluster/impl/random_cluster_selector.go
+++ b/pkg/executioncluster/impl/random_cluster_selector.go
@@ -130,7 +130,6 @@ func (s RandomClusterSelector) GetTarget(ctx context.Context, spec *executionclu
 		if flyteAdminError, ok := err.(errors.FlyteAdminError); !ok || flyteAdminError.Code() != codes.NotFound {
 			return nil, err
 		}
-		return nil, err
 	}
 	var weightedRandomList random.WeightedRandomList
 	if resource != nil && resource.Attributes.GetExecutionClusterLabel() != nil {

--- a/pkg/executioncluster/impl/random_cluster_selector_test.go
+++ b/pkg/executioncluster/impl/random_cluster_selector_test.go
@@ -144,6 +144,16 @@ func TestRandomClusterSelectorGetTargetForDomainAndExecution2(t *testing.T) {
 
 func TestRandomClusterSelectorGetRandomTarget(t *testing.T) {
 	cluster := getRandomClusterSelectorForTest(t)
+	target, err := cluster.GetTarget(context.Background(), &executioncluster.ExecutionTargetSpec{
+		Project: "",
+	})
+	assert.Nil(t, err)
+	assert.True(t, target.ID == "testcluster1" || target.ID == "testcluster2" || target.ID == "testcluster3")
+	assert.True(t, target.Enabled)
+}
+
+func TestRandomClusterSelectorGetRandomTargetUsingEmptySpec(t *testing.T) {
+	cluster := getRandomClusterSelectorForTest(t)
 	_, err := cluster.GetTarget(context.Background(), nil)
 	assert.NotNil(t, err)
 	assert.EqualError(t, err, "empty executionTargetSpec")


### PR DESCRIPTION
# TL;DR
In case there is no override in resource table, we should allow the code to go through and apply non-label based weighted random selection.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
As [commented](https://github.com/lyft/flyteadmin/pull/71/files#r475657367), it makes more sense to let the code go through and apply different selection.

BTW these unit tests relies on `GOPATH` and we should fix that.

## Tracking Issue
_Will create later_
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_