### PR TITLE
Do not depend on GOPATH to locate test data

### DIFF
--- a/pkg/executioncluster/impl/random_cluster_selector_test.go
+++ b/pkg/executioncluster/impl/random_cluster_selector_test.go
@@ -2,10 +2,8 @@ package impl
 
 import (
 	"context"
-	"go/build"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/golang/protobuf/proto"
@@ -32,13 +30,13 @@ const testDomain = "domain"
 const testWorkflow = "name"
 
 func initTestConfig(fileName string) error {
-	var searchPaths []string
-	for _, goPath := range strings.Split(build.Default.GOPATH, string(os.PathListSeparator)) {
-		searchPaths = append(searchPaths, filepath.Join(goPath, "src/github.com/lyft/flyteadmin/pkg/executioncluster/testdata/", fileName))
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
 	}
 
 	configAccessor := viper.NewAccessor(config.Options{
-		SearchPaths: searchPaths,
+		SearchPaths: []string{filepath.Join(pwd, "../testdata", fileName)},
 		StrictMode:  false,
 	})
 	return configAccessor.UpdateConfig(context.Background())

--- a/pkg/runtime/cluster_resource_provider_test.go
+++ b/pkg/runtime/cluster_resource_provider_test.go
@@ -2,9 +2,7 @@ package runtime
 
 import (
 	"context"
-	"go/build"
 	"os"
-	"strings"
 	"testing"
 
 	"path/filepath"
@@ -15,13 +13,13 @@ import (
 )
 
 func initTestClusterResourceConfig() error {
-	var searchPaths []string
-	for _, goPath := range strings.Split(build.Default.GOPATH, string(os.PathListSeparator)) {
-		searchPaths = append(searchPaths, filepath.Join(goPath, "src/github.com/lyft/flyteadmin/pkg/runtime/testdata/cluster_resource_config.yaml"))
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
 	}
 
 	configAccessor := viper.NewAccessor(config.Options{
-		SearchPaths: searchPaths,
+		SearchPaths: []string{filepath.Join(pwd, "testdata/cluster_resource_config.yaml")},
 		StrictMode:  false,
 	})
 	return configAccessor.UpdateConfig(context.TODO())

--- a/pkg/runtime/config_provider_test.go
+++ b/pkg/runtime/config_provider_test.go
@@ -2,9 +2,7 @@ package runtime
 
 import (
 	"context"
-	"go/build"
 	"os"
-	"strings"
 	"testing"
 
 	"path/filepath"
@@ -15,13 +13,13 @@ import (
 )
 
 func initTestConfig() error {
-	var searchPaths []string
-	for _, goPath := range strings.Split(build.Default.GOPATH, string(os.PathListSeparator)) {
-		searchPaths = append(searchPaths, filepath.Join(goPath, "src/github.com/lyft/flyteadmin/pkg/runtime/testdata/clusters_config.yaml"))
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
 	}
 
 	configAccessor := viper.NewAccessor(config.Options{
-		SearchPaths: searchPaths,
+		SearchPaths: []string{filepath.Join(pwd, "testdata/clusters_config.yaml")},
 		StrictMode:  false,
 	})
 	return configAccessor.UpdateConfig(context.TODO())


### PR DESCRIPTION
# TL;DR
GOPATH is not mandatory to have now and the source code may not be stored under GOPATH.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Use 	`os.Getwd()` to get current directory and then join path.

## Tracking Issue
https://github.com/lyft/flyte/issues/#498

## Follow-up issue
