### PR TITLE
#patch Allow unscoped filtering on all NamedEntity(Metadata) fields

### DIFF
--- a/pkg/common/entity.go
+++ b/pkg/common/entity.go
@@ -14,6 +14,7 @@ const (
 	Task                = "t"
 	TaskExecution       = "te"
 	Workflow            = "w"
+	NamedEntity         = "nen"
 	NamedEntityMetadata = "nem"
 )
 

--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -81,7 +81,7 @@ var executionIdentifierFields = map[string]bool{
 
 var entityMetadataFields = map[string]bool{
 	"description": true,
-	"state": true,
+	"state":       true,
 }
 
 const unrecognizedFilterFunction = "unrecognized filter function: %s"
@@ -241,6 +241,8 @@ func customizeField(field string, entity Entity) string {
 }
 
 func customizeEntity(field string, entity Entity) Entity {
+	// NamedEntity is considered a single object, but the metdata
+	// is stored using a different entity type.
 	if entity == NamedEntity && entityMetadataFields[field] {
 		return NamedEntityMetadata
 	}

--- a/pkg/common/filters.go
+++ b/pkg/common/filters.go
@@ -79,6 +79,11 @@ var executionIdentifierFields = map[string]bool{
 	"name":    true,
 }
 
+var entityMetadataFields = map[string]bool{
+	"description": true,
+	"state": true,
+}
+
 const unrecognizedFilterFunction = "unrecognized filter function: %s"
 const unsupportedFilterExpression = "unsupported filter expression: %s"
 const invalidSingleValueFilter = "invalid single value filter expression: %s"
@@ -235,14 +240,22 @@ func customizeField(field string, entity Entity) string {
 	return field
 }
 
+func customizeEntity(field string, entity Entity) Entity {
+	if entity == NamedEntity && entityMetadataFields[field] {
+		return NamedEntityMetadata
+	}
+	return entity
+}
+
 // Returns a filter which uses a single argument value.
 func NewSingleValueFilter(entity Entity, function FilterExpression, field string, value interface{}) (InlineFilter, error) {
 	if _, ok := singleValueFilters[function]; !ok {
 		return nil, GetInvalidSingleValueFilterErr(function)
 	}
 	customizedField := customizeField(field, entity)
+	customizedEntity := customizeEntity(field, entity)
 	return &inlineFilterImpl{
-		entity:   entity,
+		entity:   customizedEntity,
 		function: function,
 		field:    customizedField,
 		value:    value,

--- a/pkg/common/filters_test.go
+++ b/pkg/common/filters_test.go
@@ -48,7 +48,7 @@ func TestNewSingleBoolValueFilter(t *testing.T) {
 	assert.Equal(t, expression.Args, true)
 }
 
-func TestNewSingleValueCustomizedFilter(t *testing.T) {
+func TestNewSingleValueCustomizedFieldFilter(t *testing.T) {
 	filter, err := NewSingleValueFilter(Execution, Equal, "project", "a project")
 	assert.NoError(t, err)
 
@@ -59,6 +59,18 @@ func TestNewSingleValueCustomizedFilter(t *testing.T) {
 	expression, err = filter.GetGormJoinTableQueryExpr("node_executions")
 	assert.NoError(t, err)
 	assert.Equal(t, "node_executions.execution_project = ?", expression.Query)
+}
+
+func TestNewSingleValueCustomizedEntityFilter(t *testing.T) {
+	filter, err := NewSingleValueFilter(NamedEntity, Equal, "state", 1)
+	assert.NoError(t, err)
+
+	assert.Equal(t, NamedEntityMetadata, filter.GetEntity())
+
+	filter, err = NewSingleValueFilter(NamedEntity, Equal, "description", "test value")
+	assert.NoError(t, err)
+
+	assert.Equal(t, NamedEntityMetadata, filter.GetEntity())
 }
 
 func TestNewRepeatedValueFilter(t *testing.T) {

--- a/pkg/manager/impl/named_entity_manager.go
+++ b/pkg/manager/impl/named_entity_manager.go
@@ -86,7 +86,7 @@ func (m *NamedEntityManager) getQueryFilters(referenceEntity core.ResourceType, 
 	if len(requestFilters) == 0 {
 		return filters, nil
 	}
-	additionalFilters, err := util.ParseFilters(requestFilters, common.NamedEntityMetadata)
+	additionalFilters, err := util.ParseFilters(requestFilters, common.NamedEntity)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/manager/impl/util/filters.go
+++ b/pkg/manager/impl/util/filters.go
@@ -58,6 +58,7 @@ var filterFieldEntityPrefix = map[string]common.Entity{
 	"execution":             common.Execution,
 	"node_execution":        common.NodeExecution,
 	"task_execution":        common.TaskExecution,
+	"entities":              common.NamedEntity,
 	"named_entity_metadata": common.NamedEntityMetadata,
 }
 

--- a/pkg/repositories/gormimpl/common.go
+++ b/pkg/repositories/gormimpl/common.go
@@ -45,6 +45,7 @@ var entityToTableName = map[common.Entity]string{
 	common.Task:                "tasks",
 	common.TaskExecution:       "task_executions",
 	common.Workflow:            "workflows",
+	common.NamedEntity:         "entities",
 	common.NamedEntityMetadata: "named_entity_metadata",
 }
 


### PR DESCRIPTION
This fixes a regression where attempting to filter the list endpoint for NamedEntities on any of the base fields (such as `name`) will incorrectly exclude any records which do not have a metadata entry.

This is due to the generated query containing a `where` clause pointing at the metadata table, instead of the primary table.
For `NamedEntitiy` objects, the behavior we want is that the core and metadata fields are treated all as a single struct. The fact that we store the metadata in a separate table shouldn't require that filters be scoped.

This fixes the issue by leveraging some customization logic we already have for execution fields, but allows replacing of the filter `entity` instead. For `state` and `description`, we want the filter to be against the `NamedEntityMetadata` type. For all others, we want to use `NamedEntity`.