### PR TITLE
Ensure admin never sets task resource request > limit

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -282,7 +282,8 @@ func resolveTaskLimitsAndPlatformRequestDefaults(ctx context.Context, identifier
 		limitValue, ok := resourceLimits[resourceEntry.Name]
 		if !ok {
 			// Unexpected - at this stage both requests and limits should be populated.
-			logger.Warningf(ctx, "No limit specified for [%s] although request was set", identifier)
+			logger.Warningf(ctx, "No limit specified for [%v] resource [%s] although request was set", identifier,
+				resourceEntry.Name)
 			continue
 		}
 		if quantity.Cmp(resource.MustParse(limitValue)) == 1 {

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -265,7 +265,7 @@ func assignResourcesIfUnset(ctx context.Context, identifier *core.Identifier,
 	return resourceEntries
 }
 
-func resolveTaskLimitsAndPlatformRequestDefaults(ctx context.Context, identifier *core.Identifier,
+func checkTaskRequestsLessThanLimits(ctx context.Context, identifier *core.Identifier,
 	taskResources *core.Resources) {
 	// We choose the minimum of the platform request defaults or the limit itself for every resource request.
 	// Otherwise we can find ourselves in confusing scenarios where the injected platform request defaults exceed a
@@ -342,7 +342,7 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	task.Template.GetContainer().Resources.Limits = assignResourcesIfUnset(
 		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task), task.Template.GetContainer().Resources.Limits,
 		taskResourceSpec)
-	resolveTaskLimitsAndPlatformRequestDefaults(ctx, task.Template.Id, task.Template.GetContainer().Resources)
+	checkTaskRequestsLessThanLimits(ctx, task.Template.Id, task.Template.GetContainer().Resources)
 }
 
 func (m *ExecutionManager) launchSingleTaskExecution(

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	"github.com/lyft/flyteadmin/pkg/manager/impl/resources"
 
 	"github.com/golang/protobuf/ptypes"
@@ -263,6 +265,40 @@ func assignResourcesIfUnset(ctx context.Context, identifier *core.Identifier,
 	return resourceEntries
 }
 
+func resolveTaskLimitsAndPlatformRequestDefaults(ctx context.Context, identifier *core.Identifier,
+	taskResources *core.Resources) {
+	// We choose the minimum of the platform request defaults or the limit itself for every resource request.
+	// Otherwise we can find ourselves in confusing scenarios where the injected platform request defaults exceed a
+	// user-specified limit
+	resourceLimits := make(map[core.Resources_ResourceName]string)
+	for _, resourceEntry := range taskResources.Limits {
+		resourceLimits[resourceEntry.Name] = resourceEntry.Value
+	}
+
+	finalizedResourceRequests := make([]*core.Resources_ResourceEntry, 0, len(taskResources.Requests))
+	for _, resourceEntry := range taskResources.Requests {
+		value := resourceEntry.Value
+		quantity := resource.MustParse(resourceEntry.Value)
+		limitValue, ok := resourceLimits[resourceEntry.Name]
+		if !ok {
+			// Unexpected - at this stage both requests and limits should be populated.
+			logger.Warningf(ctx, "No limit specified for [%s] although request was set", identifier)
+			continue
+		}
+		if quantity.Cmp(resource.MustParse(limitValue)) == 1 {
+			// The quantity is greater than the limit! Course correct below.
+			logger.Debugf(ctx, "Updating requested value for task [%+v] resource [%s]. Overriding to [%s] from [%s]",
+				identifier, resourceEntry.Name, limitValue, value)
+			value = limitValue
+		}
+		finalizedResourceRequests = append(finalizedResourceRequests, &core.Resources_ResourceEntry{
+			Name:  resourceEntry.Name,
+			Value: value,
+		})
+	}
+	taskResources.Requests = finalizedResourceRequests
+}
+
 // Assumes input contains a compiled task with a valid container resource execConfig.
 //
 // Note: The system will assign a system-default value for request but for limit it will deduce it from the request
@@ -305,6 +341,7 @@ func (m *ExecutionManager) setCompiledTaskDefaults(ctx context.Context, task *co
 	task.Template.GetContainer().Resources.Limits = assignResourcesIfUnset(
 		ctx, task.Template.Id, createTaskDefaultLimits(ctx, task), task.Template.GetContainer().Resources.Limits,
 		taskResourceSpec)
+	resolveTaskLimitsAndPlatformRequestDefaults(ctx, task.Template.Id, task.Template.GetContainer().Resources)
 }
 
 func (m *ExecutionManager) launchSingleTaskExecution(

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -288,7 +288,7 @@ func checkTaskRequestsLessThanLimits(ctx context.Context, identifier *core.Ident
 		}
 		if quantity.Cmp(resource.MustParse(limitValue)) == 1 {
 			// The quantity is greater than the limit! Course correct below.
-			logger.Debugf(ctx, "Updating requested value for task [%+v] resource [%s]. Overriding to [%s] from [%s]",
+			logger.Infof(ctx, "Updating requested value for task [%+v] resource [%s]. Overriding to smaller limit value [%s] from original request [%s]",
 				identifier, resourceEntry.Name, limitValue, value)
 			value = limitValue
 		}

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -2464,6 +2464,111 @@ func TestAssignResourcesIfUnset(t *testing.T) {
 	}, assignedResources)
 }
 
+func TestResolveTaskLimitsAndPlatformRequestDefaults(t *testing.T) {
+	ctx := context.Background()
+	identifier := &core.Identifier{
+		ResourceType: core.ResourceType_TASK,
+		Project:      project,
+		Domain:       domain,
+		Name:         name,
+		Version:      version,
+	}
+	t.Run("use_limit", func(t *testing.T) {
+		resources := &core.Resources{
+			Requests: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "1",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "2",
+				},
+			},
+			Limits: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "2",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1",
+				},
+			},
+		}
+		resolveTaskLimitsAndPlatformRequestDefaults(ctx, identifier, resources)
+		assert.True(t, proto.Equal(&core.Resources{
+			Requests: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "1",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1",
+				},
+			},
+			Limits: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "2",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1",
+				},
+			},
+		}, resources))
+	})
+	t.Run("nothing_to_override", func(t *testing.T) {
+		resources := &core.Resources{
+			Requests: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "2",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1",
+				},
+			},
+			Limits: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "2",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1.5",
+				},
+			},
+		}
+		resolveTaskLimitsAndPlatformRequestDefaults(ctx, identifier, resources)
+		assert.True(t, proto.Equal(&core.Resources{
+			Requests: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "2",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1",
+				},
+			},
+			Limits: []*core.Resources_ResourceEntry{
+				{
+					Name:  core.Resources_CPU,
+					Value: "2",
+				},
+				{
+					Name:  core.Resources_MEMORY,
+					Value: "1.5",
+				},
+			},
+		}, resources))
+	})
+}
+
 func TestSetDefaults(t *testing.T) {
 	task := &core.CompiledTask{
 		Template: &core.TaskTemplate{

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -2464,7 +2464,7 @@ func TestAssignResourcesIfUnset(t *testing.T) {
 	}, assignedResources)
 }
 
-func TestResolveTaskLimitsAndPlatformRequestDefaults(t *testing.T) {
+func TestCheckTaskRequestsLessThanLimits(t *testing.T) {
 	ctx := context.Background()
 	identifier := &core.Identifier{
 		ResourceType: core.ResourceType_TASK,
@@ -2496,7 +2496,7 @@ func TestResolveTaskLimitsAndPlatformRequestDefaults(t *testing.T) {
 				},
 			},
 		}
-		resolveTaskLimitsAndPlatformRequestDefaults(ctx, identifier, resources)
+		checkTaskRequestsLessThanLimits(ctx, identifier, resources)
 		assert.True(t, proto.Equal(&core.Resources{
 			Requests: []*core.Resources_ResourceEntry{
 				{
@@ -2543,7 +2543,7 @@ func TestResolveTaskLimitsAndPlatformRequestDefaults(t *testing.T) {
 				},
 			},
 		}
-		resolveTaskLimitsAndPlatformRequestDefaults(ctx, identifier, resources)
+		checkTaskRequestsLessThanLimits(ctx, identifier, resources)
 		assert.True(t, proto.Equal(&core.Resources{
 			Requests: []*core.Resources_ResourceEntry{
 				{


### PR DESCRIPTION
# TL;DR
In the case where a user specifies a task resource limit but not the request value, admin will substitute the request value with the platform-configured default. In some cases this default can exceed the user-specified limit which is non-sensical and prevents kubernetes from ever scheduling the task.


## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Fixes user-reported bug.

## Tracking Issue
https://github.com/lyft/flyte/issues/264

## Follow-up issue
_NA_

