### PR TITLE
Support plugin override matchable resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/lib/pq v1.3.0
 	github.com/lyft/flyteidl v0.18.6
-	github.com/lyft/flytepropeller v0.3.7
+	github.com/lyft/flytepropeller v0.3.17
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jinzhu/gorm v1.9.12
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/lib/pq v1.3.0
-	github.com/lyft/flyteidl v0.18.3
+	github.com/lyft/flyteidl v0.18.6
 	github.com/lyft/flytepropeller v0.3.7
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -462,12 +462,11 @@ github.com/lyft/apimachinery v0.0.0-20191031200210-047e3ea32d7f/go.mod h1:llRdnz
 github.com/lyft/datacatalog v0.2.1/go.mod h1:ktrPvzTDUwHO5Lv0hLH38zLHnOJ++rGoAO0iQ/sIPJ4=
 github.com/lyft/flyteidl v0.17.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteidl v0.18.1/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.6 h1:HGbxHI8avEDvoPqcO2+/BoJVcP9sjOj4qwJ/wNRWuoA=
 github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteplugins v0.4.4/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
-github.com/lyft/flytepropeller v0.3.7 h1:l2AguhyhiUDCvqjHYF8XJw46gPW9j4XNZwJEAJdiEtI=
-github.com/lyft/flytepropeller v0.3.7/go.mod h1:8sNP7ZnEngNRYBMewmH4PtiRR0pus8RkjNoPqelyKX8=
+github.com/lyft/flyteplugins v0.5.1/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
+github.com/lyft/flytepropeller v0.3.17 h1:a2PVqWjnn8oNEeayAqNizMAtEixl/F3S4vd8z4kbiqI=
+github.com/lyft/flytepropeller v0.3.17/go.mod h1:T8Utxqv7B5USAX9c/Qh0lBbKXHFSgOwwaISOd9h36P4=
 github.com/lyft/flytestdlib v0.3.0 h1:nIkX4MlyYdcLLzaF35RI2P5BhARt+qMgHoFto8eVNzU=
 github.com/lyft/flytestdlib v0.3.0/go.mod h1:LJPPJlkFj+wwVWMrQT3K5JZgNhZi2mULsCG4ZYhinhU=
 github.com/lyft/flytestdlib v0.3.9 h1:NaKp9xkeWWwhVvqTOcR/FqlASy1N2gu/kN7PVe4S7YI=

--- a/go.sum
+++ b/go.sum
@@ -463,8 +463,8 @@ github.com/lyft/datacatalog v0.2.1/go.mod h1:ktrPvzTDUwHO5Lv0hLH38zLHnOJ++rGoAO0
 github.com/lyft/flyteidl v0.17.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.1/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
-github.com/lyft/flyteidl v0.18.3 h1:+O0rDCXoiui5X56DtoqquW0rqjN75jDWqAEyvcqmarI=
-github.com/lyft/flyteidl v0.18.3/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.6 h1:HGbxHI8avEDvoPqcO2+/BoJVcP9sjOj4qwJ/wNRWuoA=
+github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteplugins v0.4.4/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flytepropeller v0.3.7 h1:l2AguhyhiUDCvqjHYF8XJw46gPW9j4XNZwJEAJdiEtI=
 github.com/lyft/flytepropeller v0.3.7/go.mod h1:8sNP7ZnEngNRYBMewmH4PtiRR0pus8RkjNoPqelyKX8=

--- a/pkg/common/testutils/common.go
+++ b/pkg/common/testutils/common.go
@@ -1,0 +1,21 @@
+package testutils
+
+import "github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
+
+// Convenience method to wrap verbose boilerplate for initializing a PluginOverrides MatchingAttributes.
+func GetPluginOverridesAttributes(vals map[string][]string) *admin.MatchingAttributes {
+	overrides := make([]*admin.PluginOverride, 0, len(vals))
+	for taskType, pluginIDs := range vals {
+		overrides = append(overrides, &admin.PluginOverride{
+			TaskType: taskType,
+			PluginId: pluginIDs,
+		})
+	}
+	return &admin.MatchingAttributes{
+		Target: &admin.MatchingAttributes_PluginOverrides{
+			PluginOverrides: &admin.PluginOverrides{
+				Overrides: overrides,
+			},
+		},
+	}
+}

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -171,6 +171,12 @@ func (m *ExecutionManager) addLabelsAndAnnotations(requestSpec *admin.ExecutionS
 	return nil
 }
 
+func (m *ExecutionManager) AddPluginOverrides(ctx context.Context, requestSpec *admin.ExecutionSpec,
+	partiallyPopulatedInputs *workflowengineInterfaces.ExecuteWorkflowInput) error {
+		m.resourceManager.GetResource(ctx )
+
+	}
+
 func (m *ExecutionManager) offloadInputs(ctx context.Context, literalMap *core.LiteralMap, identifier *core.WorkflowExecutionIdentifier, key string) (storage.DataReference, error) {
 	if literalMap == nil {
 		literalMap = &core.LiteralMap{}
@@ -573,6 +579,7 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 	if err != nil {
 		return nil, nil, err
 	}
+
 
 	execInfo, err := m.workflowExecutor.ExecuteWorkflow(ctx, executeWorkflowInputs)
 	if err != nil {

--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -171,11 +171,26 @@ func (m *ExecutionManager) addLabelsAndAnnotations(requestSpec *admin.ExecutionS
 	return nil
 }
 
-func (m *ExecutionManager) AddPluginOverrides(ctx context.Context, requestSpec *admin.ExecutionSpec,
-	partiallyPopulatedInputs *workflowengineInterfaces.ExecuteWorkflowInput) error {
-		m.resourceManager.GetResource(ctx )
-
+func (m *ExecutionManager) addPluginOverrides(ctx context.Context, executionID *core.WorkflowExecutionIdentifier,
+	workflowName, launchPlanName string, partiallyPopulatedInputs *workflowengineInterfaces.ExecuteWorkflowInput) error {
+	override, err := m.resourceManager.GetResource(ctx, interfaces.ResourceRequest{
+		Project:      executionID.Project,
+		Domain:       executionID.Domain,
+		Workflow:     workflowName,
+		LaunchPlan:   launchPlanName,
+		ResourceType: admin.MatchableResource_PLUGIN_OVERRIDE,
+	})
+	if err != nil {
+		ec, ok := err.(errors.FlyteAdminError)
+		if !ok || ec.Code() != codes.NotFound {
+			return err
+		}
 	}
+	if override != nil && override.Attributes != nil && override.Attributes.GetPluginOverrides() != nil {
+		partiallyPopulatedInputs.TaskPluginOverrides = override.Attributes.GetPluginOverrides().Overrides
+	}
+	return nil
+}
 
 func (m *ExecutionManager) offloadInputs(ctx context.Context, literalMap *core.LiteralMap, identifier *core.WorkflowExecutionIdentifier, key string) (storage.DataReference, error) {
 	if literalMap == nil {
@@ -579,7 +594,11 @@ func (m *ExecutionManager) launchExecutionAndPrepareModel(
 	if err != nil {
 		return nil, nil, err
 	}
-
+	err = m.addPluginOverrides(ctx, &workflowExecutionID, launchPlan.GetSpec().WorkflowId.Name, launchPlan.Id.Name,
+		&executeWorkflowInputs)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	execInfo, err := m.workflowExecutor.ExecuteWorkflow(ctx, executeWorkflowInputs)
 	if err != nil {

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	notificationMocks "github.com/lyft/flyteadmin/pkg/async/notifications/mocks"
+	commonTestUtils "github.com/lyft/flyteadmin/pkg/common/testutils"
 	dataMocks "github.com/lyft/flyteadmin/pkg/data/mocks"
 	flyteAdminErrors "github.com/lyft/flyteadmin/pkg/errors"
 	"github.com/lyft/flyteadmin/pkg/manager/impl/executions"
@@ -2102,6 +2103,57 @@ func TestAddLabelsAndAnnotationsRuntimeLimitsObserved(t *testing.T) {
 		},
 	})
 	assert.EqualError(t, err, "Labels has too many entries [2 > 1]")
+}
+
+func TestAddPluginOverrides(t *testing.T) {
+	executionID := &core.WorkflowExecutionIdentifier{
+		Project: project,
+		Domain:  domain,
+		Name:    "unused",
+	}
+	workflowName := "workflow_name"
+	launchPlanName := "launch_plan_name"
+
+	db := repositoryMocks.NewMockRepository()
+	db.ResourceRepo().(*repositoryMocks.MockResourceRepo).GetFunction = func(ctx context.Context, ID interfaces.ResourceID) (
+		models.Resource, error) {
+		assert.Equal(t, project, ID.Project)
+		assert.Equal(t, domain, ID.Domain)
+		assert.Equal(t, workflowName, ID.Workflow)
+		assert.Equal(t, launchPlanName, ID.LaunchPlan)
+		existingAttributes := commonTestUtils.GetPluginOverridesAttributes(map[string][]string{
+			"python": {"plugin a"},
+			"hive":   {"plugin b"},
+		})
+		bytes, err := proto.Marshal(existingAttributes)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return models.Resource{
+			Project:    project,
+			Domain:     domain,
+			Attributes: bytes,
+		}, nil
+	}
+	partiallyPopulatedInputs := workflowengineInterfaces.ExecuteWorkflowInput{}
+
+	execManager := NewExecutionManager(
+		db, getMockExecutionsConfigProvider(), getMockStorageForExecTest(context.Background()), workflowengineMocks.NewMockExecutor(),
+		mockScope.NewTestScope(), mockScope.NewTestScope(), &mockPublisher, mockExecutionRemoteURL, nil, nil)
+
+	err := execManager.(*ExecutionManager).addPluginOverrides(
+		context.Background(), executionID, workflowName, launchPlanName, &partiallyPopulatedInputs)
+	assert.NoError(t, err)
+	assert.Len(t, partiallyPopulatedInputs.TaskPluginOverrides, 2)
+	for _, override := range partiallyPopulatedInputs.TaskPluginOverrides {
+		if override.TaskType == "python" {
+			assert.EqualValues(t, []string{"plugin a"}, override.PluginId)
+		} else if override.TaskType == "hive" {
+			assert.EqualValues(t, []string{"plugin b"}, override.PluginId)
+		} else {
+			t.Errorf("Unexpected task type [%s] plugin override committed to db", override.TaskType)
+		}
+	}
 }
 
 func TestGetExecution_Legacy(t *testing.T) {

--- a/pkg/manager/impl/validation/attributes_validator.go
+++ b/pkg/manager/impl/validation/attributes_validator.go
@@ -26,6 +26,8 @@ func validateMatchingAttributes(attributes *admin.MatchingAttributes, identifier
 		return admin.MatchableResource_EXECUTION_QUEUE, nil
 	} else if attributes.GetExecutionClusterLabel() != nil {
 		return admin.MatchableResource_EXECUTION_CLUSTER_LABEL, nil
+	} else if attributes.GetPluginOverrides() != nil {
+		return admin.MatchableResource_PLUGIN_OVERRIDE, nil
 	}
 	return defaultMatchableResource, errors.NewFlyteAdminErrorf(codes.InvalidArgument,
 		"Unrecognized matching attributes type for request %s", identifier)

--- a/pkg/manager/impl/validation/attributes_validator_test.go
+++ b/pkg/manager/impl/validation/attributes_validator_test.go
@@ -68,6 +68,23 @@ func TestValidateMatchingAttributes(t *testing.T) {
 			admin.MatchableResource_EXECUTION_QUEUE,
 			nil,
 		},
+		{
+			&admin.MatchingAttributes{
+				Target: &admin.MatchingAttributes_PluginOverrides{
+					PluginOverrides: &admin.PluginOverrides{
+						Overrides: []*admin.PluginOverride{
+							{
+								TaskType: "python",
+								PluginId: []string{"foo"},
+							},
+						},
+					},
+				},
+			},
+			"foo",
+			admin.MatchableResource_PLUGIN_OVERRIDE,
+			nil,
+		},
 	}
 	for _, tc := range testCases {
 		matchableResource, err := validateMatchingAttributes(tc.attributes, tc.identifier)

--- a/pkg/repositories/transformers/resource.go
+++ b/pkg/repositories/transformers/resource.go
@@ -75,10 +75,10 @@ func MergeUpdateWorkflowAttributes(ctx context.Context, model models.Resource, r
 		model.Attributes = marshaledAttributes
 		return model, nil
 	default:
-		logger.Warningf(ctx, "Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+		logger.Warningf(ctx, "Tried to merge-update an unsupported resource type [%s] for [%+v]",
 			resource.String(), resourceID)
 		return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
-			"Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+			"Tried to merge-update an unsupported resource type [%s] for [%+v]",
 			resource.String(), resourceID)
 	}
 }
@@ -131,10 +131,10 @@ func MergeUpdateProjectDomainAttributes(ctx context.Context, model models.Resour
 		model.Attributes = marshaledAttributes
 		return model, nil
 	default:
-		logger.Warningf(ctx, "Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+		logger.Warningf(ctx, "Tried to merge-update an unsupported resource type [%s] for [%+v]",
 			resource.String(), resourceID)
 		return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
-			"Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+			"Tried to merge-update an unsupported resource type [%s] for [%+v]",
 			resource.String(), resourceID)
 	}
 }

--- a/pkg/repositories/transformers/resource.go
+++ b/pkg/repositories/transformers/resource.go
@@ -1,7 +1,11 @@
 package transformers
 
 import (
+	"context"
+
 	"github.com/golang/protobuf/proto"
+	repoInterfaces "github.com/lyft/flyteadmin/pkg/repositories/interfaces"
+	"github.com/lyft/flytestdlib/logger"
 
 	"github.com/lyft/flyteadmin/pkg/errors"
 	"github.com/lyft/flyteadmin/pkg/repositories/models"
@@ -22,6 +26,61 @@ func WorkflowAttributesToResourceModel(attributes admin.WorkflowAttributes, reso
 		Priority:     models.ResourcePriorityWorkflowLevel,
 		Attributes:   attributeBytes,
 	}, nil
+}
+
+func mergeUpdatePluginOverrides(existingAttributes admin.MatchingAttributes,
+	newMatchingAttributes *admin.MatchingAttributes) *admin.MatchingAttributes {
+	taskPluginOverrides := make(map[string]*admin.PluginOverride)
+	if existingAttributes.GetPluginOverrides() != nil && len(existingAttributes.GetPluginOverrides().Overrides) > 0 {
+		for _, pluginOverride := range existingAttributes.GetPluginOverrides().Overrides {
+			taskPluginOverrides[pluginOverride.TaskType] = pluginOverride
+		}
+	}
+	if newMatchingAttributes.GetPluginOverrides() != nil &&
+		len(newMatchingAttributes.GetPluginOverrides().Overrides) > 0 {
+		for _, pluginOverride := range newMatchingAttributes.GetPluginOverrides().Overrides {
+			taskPluginOverrides[pluginOverride.TaskType] = pluginOverride
+		}
+	}
+
+	updatedPluginOverrides := make([]*admin.PluginOverride, 0, len(taskPluginOverrides))
+	for _, pluginOverride := range taskPluginOverrides {
+		updatedPluginOverrides = append(updatedPluginOverrides, pluginOverride)
+	}
+	return &admin.MatchingAttributes{
+		Target: &admin.MatchingAttributes_PluginOverrides{
+			PluginOverrides: &admin.PluginOverrides{
+				Overrides: updatedPluginOverrides,
+			},
+		},
+	}
+}
+
+func MergeUpdateWorkflowAttributes(ctx context.Context, model models.Resource, resource admin.MatchableResource,
+	resourceID *repoInterfaces.ResourceID, workflowAttributes *admin.WorkflowAttributes) (models.Resource, error) {
+	switch resource {
+	case admin.MatchableResource_PLUGIN_OVERRIDE:
+		var existingAttributes admin.MatchingAttributes
+		err := proto.Unmarshal(model.Attributes, &existingAttributes)
+		if err != nil {
+			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
+				"Unable to unmarshal existing resource attributes for [%+v] with err: %v", resourceID, err)
+		}
+		updatedAttributes := mergeUpdatePluginOverrides(existingAttributes, workflowAttributes.GetMatchingAttributes())
+		marshaledAttributes, err := proto.Marshal(updatedAttributes)
+		if err != nil {
+			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
+				"Failed to marshal merge-updated attributes for [%+v] with err: %v", resourceID, err)
+		}
+		model.Attributes = marshaledAttributes
+		return model, nil
+	default:
+		logger.Warningf(ctx, "Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+			resource.String(), resourceID)
+		return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
+			"Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+			resource.String(), resourceID)
+	}
 }
 
 func FromResourceModelToWorkflowAttributes(model models.Resource) (admin.WorkflowAttributes, error) {
@@ -51,6 +110,33 @@ func ProjectDomainAttributesToResourceModel(attributes admin.ProjectDomainAttrib
 		Priority:     models.ResourcePriorityProjectDomainLevel,
 		Attributes:   attributeBytes,
 	}, nil
+}
+
+func MergeUpdateProjectDomainAttributes(ctx context.Context, model models.Resource, resource admin.MatchableResource,
+	resourceID *repoInterfaces.ResourceID, attributes *admin.ProjectDomainAttributes) (models.Resource, error) {
+	switch resource {
+	case admin.MatchableResource_PLUGIN_OVERRIDE:
+		var existingAttributes admin.MatchingAttributes
+		err := proto.Unmarshal(model.Attributes, &existingAttributes)
+		if err != nil {
+			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
+				"Unable to unmarshal existing resource attributes for [%+v] with err: %v", resourceID, err)
+		}
+		updatedAttributes := mergeUpdatePluginOverrides(existingAttributes, attributes.GetMatchingAttributes())
+		marshaledAttributes, err := proto.Marshal(updatedAttributes)
+		if err != nil {
+			return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
+				"Failed to marshal merge-updated attributes for [%+v] with err: %v", resourceID, err)
+		}
+		model.Attributes = marshaledAttributes
+		return model, nil
+	default:
+		logger.Warningf(ctx, "Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+			resource.String(), resourceID)
+		return models.Resource{}, errors.NewFlyteAdminErrorf(codes.Internal,
+			"Tried to create or merge-update an unsupported resource type [%s] for [%+v]",
+			resource.String(), resourceID)
+	}
 }
 
 func FromResourceModelToProjectDomainAttributes(model models.Resource) (admin.ProjectDomainAttributes, error) {

--- a/pkg/workflowengine/impl/propeller_executor.go
+++ b/pkg/workflowengine/impl/propeller_executor.go
@@ -91,6 +91,23 @@ func (c *FlytePropeller) addPermissions(launchPlan admin.LaunchPlan, flyteWf *v1
 	}
 }
 
+func addExecutionOverrides(taskPluginOverrides []*admin.PluginOverride, flyteWf *v1alpha1.FlyteWorkflow) {
+	if len(taskPluginOverrides) == 0 {
+		return
+	}
+	executionConfig := v1alpha1.ExecutionConfig{
+		TaskPluginImpls: make(map[string]v1alpha1.TaskPluginOverride),
+	}
+	for _, override := range taskPluginOverrides {
+		executionConfig.TaskPluginImpls[override.TaskType] = v1alpha1.TaskPluginOverride{
+			PluginIDs:             override.PluginId,
+			MissingPluginBehavior: override.MissingPluginBehavior,
+		}
+
+	}
+	flyteWf.ExecutionConfig = executionConfig
+}
+
 func (c *FlytePropeller) ExecuteWorkflow(ctx context.Context, input interfaces.ExecuteWorkflowInput) (*interfaces.ExecutionInfo, error) {
 	if input.ExecutionID == nil {
 		c.metrics.InvalidExecutionID.Inc()
@@ -121,6 +138,7 @@ func (c *FlytePropeller) ExecuteWorkflow(ctx context.Context, input interfaces.E
 	flyteWf.Labels = labels
 	annotations := addMapValues(input.Annotations, flyteWf.Annotations)
 	flyteWf.Annotations = annotations
+	addExecutionOverrides(input.TaskPluginOverrides, flyteWf)
 
 	if input.Reference.Spec.RawOutputDataConfig != nil {
 		flyteWf.RawOutputDataConfig = v1alpha1.RawOutputDataConfig{

--- a/pkg/workflowengine/impl/propeller_executor.go
+++ b/pkg/workflowengine/impl/propeller_executor.go
@@ -92,11 +92,11 @@ func (c *FlytePropeller) addPermissions(launchPlan admin.LaunchPlan, flyteWf *v1
 }
 
 func addExecutionOverrides(taskPluginOverrides []*admin.PluginOverride, flyteWf *v1alpha1.FlyteWorkflow) {
-	if len(taskPluginOverrides) == 0 {
-		return
-	}
 	executionConfig := v1alpha1.ExecutionConfig{
 		TaskPluginImpls: make(map[string]v1alpha1.TaskPluginOverride),
+	}
+	if len(taskPluginOverrides) == 0 {
+		return
 	}
 	for _, override := range taskPluginOverrides {
 		executionConfig.TaskPluginImpls[override.TaskType] = v1alpha1.TaskPluginOverride{

--- a/pkg/workflowengine/impl/propeller_executor_test.go
+++ b/pkg/workflowengine/impl/propeller_executor_test.go
@@ -147,6 +147,13 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 				"customannotation":       "annotationval",
 			}
 			assert.EqualValues(t, expectedAnnotations, workflow.Annotations)
+
+			assert.EqualValues(t, map[string]v1alpha1.TaskPluginOverride{
+				"python": {
+					PluginIDs:             []string{"plugin a"},
+					MissingPluginBehavior: admin.PluginOverride_USE_DEFAULT,
+				},
+			}, workflow.ExecutionConfig.TaskPluginImpls)
 			return nil, nil
 		},
 	}
@@ -183,6 +190,13 @@ func TestExecuteWorkflowHappyCase(t *testing.T) {
 			},
 			Annotations: map[string]string{
 				"customannotation": "annotationval",
+			},
+			TaskPluginOverrides: []*admin.PluginOverride{
+				{
+					TaskType:              "python",
+					PluginId:              []string{"plugin a"},
+					MissingPluginBehavior: admin.PluginOverride_USE_DEFAULT,
+				},
 			},
 		})
 	assert.Nil(t, err)

--- a/pkg/workflowengine/interfaces/executor.go
+++ b/pkg/workflowengine/interfaces/executor.go
@@ -10,15 +10,15 @@ import (
 )
 
 type ExecuteWorkflowInput struct {
-	ExecutionID    *core.WorkflowExecutionIdentifier
-	WfClosure      core.CompiledWorkflowClosure
-	Inputs         *core.LiteralMap
-	Reference      admin.LaunchPlan
-	AcceptedAt     time.Time
-	Labels         map[string]string
-	Annotations    map[string]string
-	QueueingBudget time.Duration
-	TaskPluginOverrides []admin.PluginOverride
+	ExecutionID         *core.WorkflowExecutionIdentifier
+	WfClosure           core.CompiledWorkflowClosure
+	Inputs              *core.LiteralMap
+	Reference           admin.LaunchPlan
+	AcceptedAt          time.Time
+	Labels              map[string]string
+	Annotations         map[string]string
+	QueueingBudget      time.Duration
+	TaskPluginOverrides []*admin.PluginOverride
 }
 
 type ExecuteTaskInput struct {

--- a/pkg/workflowengine/interfaces/executor.go
+++ b/pkg/workflowengine/interfaces/executor.go
@@ -18,6 +18,7 @@ type ExecuteWorkflowInput struct {
 	Labels         map[string]string
 	Annotations    map[string]string
 	QueueingBudget time.Duration
+	TaskPluginOverrides []admin.PluginOverride
 }
 
 type ExecuteTaskInput struct {

--- a/tests/launch_plan_test.go
+++ b/tests/launch_plan_test.go
@@ -53,6 +53,11 @@ func getWorkflowCreateRequest() admin.WorkflowCreateRequest {
 						},
 					},
 				},
+				Nodes: []*core.Node{
+					{
+						Id: "I'm a node",
+					},
+				},
 			},
 		},
 	}


### PR DESCRIPTION
# TL;DR
This change introduces adding plugin overrides to the flyte workflow CRD when they exist for a matching CreateExecutionRequest.

Additionally, this change also adds a logical merge functionality for plugin overrides so that individual users do not have to do a get before update. Rather, any task type plugin overrides they specify will be saved in addition to existing overrides for _other task types_. The admin-internal sequence for get & update is not transactional and this could cause small errors to arise, but since system administrators will be infrequently calling the master update endpoint this should not really be a concern.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
https://docs.google.com/document/d/1OWYJ2ggr0pWvOdOKkf04NLtj2Rf32dMVYvAYMoyeU48/edit?usp=sharing

## Tracking Issue
https://github.com/lyft/flyte/issues/499

## Follow-up issue
_NA_
