### PR TITLE
Fix integration tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,8 +25,8 @@ require (
 	github.com/jinzhu/gorm v1.9.12
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/lib/pq v1.3.0
-	github.com/lyft/flyteidl v0.18.3
-	github.com/lyft/flytepropeller v0.3.7
+	github.com/lyft/flyteidl v0.18.6
+	github.com/lyft/flytepropeller v0.3.16
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1
 	github.com/mitchellh/mapstructure v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -465,9 +465,14 @@ github.com/lyft/flyteidl v0.18.0/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/
 github.com/lyft/flyteidl v0.18.1/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteidl v0.18.3 h1:+O0rDCXoiui5X56DtoqquW0rqjN75jDWqAEyvcqmarI=
 github.com/lyft/flyteidl v0.18.3/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
+github.com/lyft/flyteidl v0.18.6 h1:HGbxHI8avEDvoPqcO2+/BoJVcP9sjOj4qwJ/wNRWuoA=
+github.com/lyft/flyteidl v0.18.6/go.mod h1:/zQXxuHO11u/saxTTZc8oYExIGEShXB+xCB1/F1Cu20=
 github.com/lyft/flyteplugins v0.4.4/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
+github.com/lyft/flyteplugins v0.5.1/go.mod h1:8zhqFG9BzbHNQGEXzGYltTJLD+KTmQZkanxXgeFI25c=
 github.com/lyft/flytepropeller v0.3.7 h1:l2AguhyhiUDCvqjHYF8XJw46gPW9j4XNZwJEAJdiEtI=
 github.com/lyft/flytepropeller v0.3.7/go.mod h1:8sNP7ZnEngNRYBMewmH4PtiRR0pus8RkjNoPqelyKX8=
+github.com/lyft/flytepropeller v0.3.16 h1:a6KbvtDRMMVEUlVTqQ9h9IOehUerk3dT+pvsN5Ql/4o=
+github.com/lyft/flytepropeller v0.3.16/go.mod h1:GArCzcLAZ48OacGUsHUA3f028ixoU8CVZOMikyjEdNY=
 github.com/lyft/flytestdlib v0.3.0 h1:nIkX4MlyYdcLLzaF35RI2P5BhARt+qMgHoFto8eVNzU=
 github.com/lyft/flytestdlib v0.3.0/go.mod h1:LJPPJlkFj+wwVWMrQT3K5JZgNhZi2mULsCG4ZYhinhU=
 github.com/lyft/flytestdlib v0.3.9 h1:NaKp9xkeWWwhVvqTOcR/FqlASy1N2gu/kN7PVe4S7YI=

--- a/tests/launch_plan_test.go
+++ b/tests/launch_plan_test.go
@@ -53,6 +53,24 @@ func getWorkflowCreateRequest() admin.WorkflowCreateRequest {
 						},
 					},
 				},
+				Nodes: []*core.Node{
+					{
+						Id: "I'm a node",
+						Target: &core.Node_TaskNode{
+							TaskNode: &core.TaskNode{
+								Reference: &core.TaskNode_ReferenceId{
+									ReferenceId: &core.Identifier{
+										ResourceType: core.ResourceType_TASK,
+										Project:      "admintests",
+										Domain:       "development",
+										Name:         "name_a",
+										Version:      "123",
+									},
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -163,6 +181,7 @@ func TestCreateLaunchPlan(t *testing.T) {
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
+	insertTasksForTests(t, client)
 
 	createWorkflowReq := getWorkflowCreateRequest()
 
@@ -180,6 +199,7 @@ func TestGetLaunchPlanHTTP(t *testing.T) {
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
 
+	insertTasksForTests(t, client)
 	createWorkflowReq := getWorkflowCreateRequest()
 
 	_, err := client.CreateWorkflow(ctx, &createWorkflowReq)
@@ -213,6 +233,7 @@ func TestEnableDisableLaunchPlan(t *testing.T) {
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
 
+	insertTasksForTests(t, client)
 	createWorkflowReq := getWorkflowCreateRequest()
 
 	_, err := client.CreateWorkflow(ctx, &createWorkflowReq)
@@ -268,6 +289,7 @@ func TestUpdateActiveLaunchPlanVersion(t *testing.T) {
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
 
+	insertTasksForTests(t, client)
 	createWorkflowReq := getWorkflowCreateRequest()
 
 	_, err := client.CreateWorkflow(ctx, &createWorkflowReq)
@@ -322,6 +344,7 @@ func TestListLaunchPlans(t *testing.T) {
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 
+	insertTasksForTests(t, client)
 	createWorkflowReq := getWorkflowCreateRequest()
 
 	_, err := client.CreateWorkflow(ctx, &createWorkflowReq)
@@ -391,6 +414,7 @@ func TestListLaunchPlansFilterOnSchedule(t *testing.T) {
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 
+	insertTasksForTests(t, client)
 	createWorkflowReq := getWorkflowCreateRequest()
 
 	_, err := client.CreateWorkflow(ctx, &createWorkflowReq)

--- a/tests/named_entity_test.go
+++ b/tests/named_entity_test.go
@@ -305,6 +305,7 @@ func TestUpdateNamedEntityState(t *testing.T) {
 	ctx := context.Background()
 
 	defer conn.Close()
+	insertTasksForTests(t, client)
 	insertWorkflowsForTests(t, client)
 
 	result, err := client.ListNamedEntities(ctx, &admin.NamedEntityListRequest{

--- a/tests/shared.go
+++ b/tests/shared.go
@@ -82,6 +82,24 @@ func insertWorkflowsForTests(t *testing.T, client service.AdminServiceClient) {
 										},
 									},
 								},
+								Nodes: []*core.Node{
+									{
+										Id: "I'm a node",
+										Target: &core.Node_TaskNode{
+											TaskNode: &core.TaskNode{
+												Reference: &core.TaskNode_ReferenceId{
+													ReferenceId: &core.Identifier{
+														ResourceType: core.ResourceType_TASK,
+														Project:      project,
+														Domain:       domain,
+														Name:         name,
+														Version:      version,
+													},
+												},
+											},
+										},
+									},
+								},
 							},
 						},
 					}

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -5,6 +5,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
 	"io/ioutil"
 	"net/http"
 	"testing"
@@ -17,9 +18,18 @@ import (
 )
 
 func TestCreateWorkflow(t *testing.T) {
+	truncateAllTablesForTestingOnly()
 	ctx := context.Background()
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
+
+	taskCreateReq := testutils.GetValidTaskRequest()
+	taskCreateReq.Id.Project = "admintests"
+	taskCreateReq.Id.Domain = "development"
+	taskCreateReq.Id.Name = "simple task"
+	_, err := client.CreateTask(ctx, &taskCreateReq)
+	assert.NoError(t, err)
+
 
 	identifier := core.Identifier{
 		ResourceType: core.ResourceType_WORKFLOW,
@@ -34,11 +44,23 @@ func TestCreateWorkflow(t *testing.T) {
 			Template: &core.WorkflowTemplate{
 				Id:        &identifier,
 				Interface: &core.TypedInterface{},
+				Nodes: []*core.Node{
+					{
+						Id: "I'm a node",
+						Target: &core.Node_TaskNode{
+							TaskNode: &core.TaskNode{
+								Reference: &core.TaskNode_ReferenceId{
+									ReferenceId: taskCreateReq.Id,
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
 
-	_, err := client.CreateWorkflow(ctx, &req)
+	_, err = client.CreateWorkflow(ctx, &req)
 	assert.Nil(t, err)
 }
 
@@ -46,6 +68,7 @@ func TestGetWorkflows(t *testing.T) {
 	truncateAllTablesForTestingOnly()
 	client, conn := GetTestAdminServiceClient()
 	defer conn.Close()
+	insertTasksForTests(t, client)
 	insertWorkflowsForTests(t, client)
 
 	t.Run("TestGetWorkflowGrpc", testGetWorkflowGrpc)


### PR DESCRIPTION
# TL;DR
https://github.com/lyft/flytepropeller/pull/187 adds a check to flytepropeller so that a workflow lacking nodes fails during registration/compilation time. Admin integration tests use incomplete workflow skeletons that do not include any nodes and therefore fail.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [x] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
 _How did you fix the bug, make the feature etc. Link to any design docs etc_

## Tracking Issue
https://github.com/lyft/flyte/issues/<number>

## Follow-up issue
_NA_
OR
_https://github.com/lyft/flyte/issues/<number>_
