### PR TITLE
Fix list executions for single task

### DIFF
--- a/pkg/manager/impl/execution_manager.go
+++ b/pkg/manager/impl/execution_manager.go
@@ -1153,11 +1153,16 @@ func (m *ExecutionManager) ListExecutions(
 		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid pagination token %s for ListExecutions",
 			request.Token)
 	}
+	joinTableEntities := make(map[common.Entity]bool)
+	for _, filter := range filters {
+		joinTableEntities[filter.GetEntity()] = true
+	}
 	listExecutionsInput := repositoryInterfaces.ListResourceInput{
-		Limit:         int(request.Limit),
-		Offset:        offset,
-		InlineFilters: filters,
-		SortParameter: sortParameter,
+		Limit:             int(request.Limit),
+		Offset:            offset,
+		InlineFilters:     filters,
+		SortParameter:     sortParameter,
+		JoinTableEntities: joinTableEntities,
 	}
 	output, err := m.db.ExecutionRepo().List(ctx, listExecutionsInput)
 	if err != nil {

--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -1462,6 +1462,9 @@ func TestListExecutions(t *testing.T) {
 		assert.Equal(t, limit, input.Limit)
 		assert.Equal(t, "domain asc", input.SortParameter.GetGormOrderExpr())
 		assert.Equal(t, 2, input.Offset)
+		assert.EqualValues(t, map[common.Entity]bool{
+			common.Execution: true,
+		}, input.JoinTableEntities)
 		return interfaces.ExecutionCollectionOutput{
 			Executions: []models.Execution{
 				{

--- a/pkg/repositories/gormimpl/execution_repo.go
+++ b/pkg/repositories/gormimpl/execution_repo.go
@@ -111,8 +111,7 @@ func (r *ExecutionRepo) List(ctx context.Context, input interfaces.ListResourceI
 	}
 	var executions []models.Execution
 	tx := r.db.Limit(input.Limit).Offset(input.Offset)
-	// And add join condition (joining multiple tables is fine even we only filter on a subset of table attributes).
-	// (this query isn't called for deletes).
+	// And add join condition as required by user-specified filters (which can potentially include join table attrs).
 	if ok := input.JoinTableEntities[common.LaunchPlan]; ok {
 		tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.launch_plan_id = %s.id",
 			launchPlanTableName, executionTableName, launchPlanTableName))

--- a/pkg/repositories/gormimpl/execution_repo.go
+++ b/pkg/repositories/gormimpl/execution_repo.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/lyft/flyteadmin/pkg/common"
+
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/core"
 
 	"github.com/jinzhu/gorm"
@@ -111,10 +113,18 @@ func (r *ExecutionRepo) List(ctx context.Context, input interfaces.ListResourceI
 	tx := r.db.Limit(input.Limit).Offset(input.Offset)
 	// And add join condition (joining multiple tables is fine even we only filter on a subset of table attributes).
 	// (this query isn't called for deletes).
-	tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.launch_plan_id = %s.id",
-		launchPlanTableName, executionTableName, launchPlanTableName))
-	tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.workflow_id = %s.id",
-		workflowTableName, executionTableName, workflowTableName))
+	if ok := input.JoinTableEntities[common.LaunchPlan]; ok {
+		tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.launch_plan_id = %s.id",
+			launchPlanTableName, executionTableName, launchPlanTableName))
+	}
+	if ok := input.JoinTableEntities[common.Workflow]; ok {
+		tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.workflow_id = %s.id",
+			workflowTableName, executionTableName, workflowTableName))
+	}
+	if ok := input.JoinTableEntities[common.Task]; ok {
+		tx = tx.Joins(fmt.Sprintf("INNER JOIN %s ON %s.task_id = %s.id",
+			taskTableName, executionTableName, taskTableName))
+	}
 
 	// Apply filters
 	tx, err := applyScopedFilters(tx, input.InlineFilters, input.MapFilters)

--- a/pkg/repositories/interfaces/common.go
+++ b/pkg/repositories/interfaces/common.go
@@ -20,8 +20,10 @@ type ListResourceInput struct {
 	// MapFilters refers to primary entity filters defined as map values rather than inline sql queries.
 	// These exist to permit filtering on "IS NULL" which isn't permitted with inline filter queries and
 	// pq driver value substitution.
-	MapFilters        []common.MapFilter
-	SortParameter     common.SortParameter
+	MapFilters    []common.MapFilter
+	SortParameter common.SortParameter
+	// A set of the entities (besides the primary table being queries) that should be joined with when performing
+	// the list query. This enables filtering on non-primary entity attributes.
 	JoinTableEntities map[common.Entity]bool
 }
 

--- a/pkg/repositories/interfaces/common.go
+++ b/pkg/repositories/interfaces/common.go
@@ -20,8 +20,9 @@ type ListResourceInput struct {
 	// MapFilters refers to primary entity filters defined as map values rather than inline sql queries.
 	// These exist to permit filtering on "IS NULL" which isn't permitted with inline filter queries and
 	// pq driver value substitution.
-	MapFilters    []common.MapFilter
-	SortParameter common.SortParameter
+	MapFilters        []common.MapFilter
+	SortParameter     common.SortParameter
+	JoinTableEntities map[common.Entity]bool
 }
 
 // Describes a set of resources for which to apply attribute updates.

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -5,10 +5,11 @@ package tests
 import (
 	"context"
 	"fmt"
-	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
 	"io/ioutil"
 	"net/http"
 	"testing"
+
+	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
 
 	"github.com/golang/protobuf/proto"
 
@@ -29,7 +30,6 @@ func TestCreateWorkflow(t *testing.T) {
 	taskCreateReq.Id.Name = "simple task"
 	_, err := client.CreateTask(ctx, &taskCreateReq)
 	assert.NoError(t, err)
-
 
 	identifier := core.Identifier{
 		ResourceType: core.ResourceType_WORKFLOW,


### PR DESCRIPTION
# TL;DR
In the case of single task executions the reference `launch_plan_id` in the executions database model is 0. Likewise, for conventional executions the `task_id` is set to 0 and the launch plan is referenced instead. This poses a problem because we always inner join the executions table with the workflows and launch plans table (and as of this PR, now tasks too) when listing executions to permit filtering on these join table attributes. This change updates the joins to only be included when specific filters referencing these joinable entities exist.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/lyft/flyte/issues/542

## Follow-up issue
_NA_
