### PR TITLE
Validate Project Requests on Create/Update

### DIFF
--- a/pkg/manager/impl/project_manager.go
+++ b/pkg/manager/impl/project_manager.go
@@ -70,9 +70,8 @@ func (m *ProjectManager) UpdateProject(ctx context.Context, projectUpdate admin.
 		return nil, err
 	}
 
-	// Run validation on the request, specifically checking for labels, and return err if validation does not succeed.
-	err = validation.ValidateProjectLabels(projectUpdate)
-	if err != nil {
+	// Run validation on the request and return err if validation does not succeed.
+	if err := validation.ValidateProject(projectUpdate); err != nil {
 		return nil, err
 	}
 

--- a/pkg/manager/impl/validation/project_validator_test.go
+++ b/pkg/manager/impl/validation/project_validator_test.go
@@ -93,11 +93,134 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 			},
 			expectedError: "project_description cannot exceed 300 characters",
 		},
+		{
+			request: admin.ProjectRegisterRequest{
+				Project: &admin.Project{
+					Id:   "proj",
+					Name: "name",
+					Labels: &admin.Labels{
+						Values: map[string]string{
+							"#badkey": "foo",
+							"bar":     "baz",
+						},
+					},
+				},
+			},
+			expectedError: "invalid label key [#badkey]: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
+		{
+			request: admin.ProjectRegisterRequest{
+				Project: &admin.Project{
+					Id:   "proj",
+					Name: "name",
+					Labels: &admin.Labels{
+						Values: map[string]string{
+							"foo": ".bad-label-value",
+							"bar": "baz",
+						},
+					},
+				},
+			},
+			expectedError: "invalid label value [.bad-label-value]: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
 	}
 
 	for _, val := range testValues {
 		t.Run(val.expectedError, func(t *testing.T) {
 			assert.EqualError(t, ValidateProjectRegisterRequest(val.request), val.expectedError)
+		})
+	}
+}
+
+func TestValidateProject_ValidProject(t *testing.T) {
+	assert.Nil(t, ValidateProject(admin.Project{
+		Id:          "proj",
+		Name:        "proj",
+		Description: "An amazing description for this project",
+		Labels: &admin.Labels{
+			Values: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}))
+}
+
+func TestValidateProject(t *testing.T) {
+	type testValue struct {
+		project       admin.Project
+		expectedError string
+	}
+	testValues := []testValue{
+		{
+			project: admin.Project{
+				Name: "proj",
+				Domains: []*admin.Domain{
+					{
+						Id:   "foo",
+						Name: "foo",
+					},
+				},
+			},
+			expectedError: "missing project_id",
+		},
+		{
+			project: admin.Project{
+				Id:   "%)(*&",
+				Name: "proj",
+			},
+			expectedError: "invalid project id [%)(*&]: [a DNS-1123 label must consist of lower case alphanumeric " +
+				"characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or " +
+				"'123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
+		{
+			project: admin.Project{
+				Id: "proj",
+			},
+			expectedError: "missing project_name",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "proj",
+				Domains: []*admin.Domain{
+					{
+						Id:   "foo",
+						Name: "foo",
+					},
+					{
+						Id: "foo",
+					},
+				},
+			},
+			expectedError: "Domains are currently only set system wide. Please retry without domains included in your request.",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "name",
+				// 301 character string
+				Description: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamelongn",
+			},
+			expectedError: "project_description cannot exceed 300 characters",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "name",
+				Labels: &admin.Labels{
+					Values: map[string]string{
+						"#badkey": "foo",
+						"bar":     "baz",
+					},
+				},
+			},
+			expectedError: "invalid label key [#badkey]: [a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
+		},
+	}
+
+	for _, val := range testValues {
+		t.Run(val.expectedError, func(t *testing.T) {
+			assert.EqualError(t, ValidateProject(val.project), val.expectedError)
 		})
 	}
 }

--- a/pkg/manager/impl/validation/project_validator_test.go
+++ b/pkg/manager/impl/validation/project_validator_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
@@ -63,6 +64,15 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 				},
 			},
 			expectedError: "missing project_name",
+		},
+		{
+			request: admin.ProjectRegisterRequest{
+				Project: &admin.Project{
+					Id:   "proj",
+					Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
+				},
+			},
+			expectedError: "project_name cannot exceed 64 characters",
 		},
 		{
 			request: admin.ProjectRegisterRequest{
@@ -181,6 +191,13 @@ func TestValidateProject(t *testing.T) {
 		{
 			project: admin.Project{
 				Id:   "proj",
+				Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
+			},
+			expectedError: "project_name cannot exceed 64 characters",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
 				Name: "proj",
 				Domains: []*admin.Domain{
 					{
@@ -208,6 +225,16 @@ func TestValidateProject(t *testing.T) {
 				Id:   "proj",
 				Name: "name",
 				Labels: &admin.Labels{
+					Values: createLabelsMap(17),
+				},
+			},
+			expectedError: "labels map cannot exceed 16 entries",
+		},
+		{
+			project: admin.Project{
+				Id:   "proj",
+				Name: "name",
+				Labels: &admin.Labels{
 					Values: map[string]string{
 						"#badkey": "foo",
 						"bar":     "baz",
@@ -223,6 +250,14 @@ func TestValidateProject(t *testing.T) {
 			assert.EqualError(t, ValidateProject(val.project), val.expectedError)
 		})
 	}
+}
+
+func createLabelsMap(size int) map[string]string {
+	result := make(map[string]string, size)
+	for i := 0; i < size; i++ {
+		result["key-"+strconv.Itoa(i)] = "value"
+	}
+	return result
 }
 
 func TestValidateProjectAndDomain(t *testing.T) {

--- a/pkg/manager/impl/validation/validation.go
+++ b/pkg/manager/impl/validation/validation.go
@@ -34,6 +34,14 @@ func ValidateMaxLengthStringField(field string, fieldName string, limit int) err
 	return nil
 }
 
+// Validates that a map field does not exceed a certain amount of entries
+func ValidateMaxMapLengthField(m map[string]string, fieldName string, limit int) error {
+	if len(m) > limit {
+		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "%s map cannot exceed %d entries", fieldName, limit)
+	}
+	return nil
+}
+
 func ValidateIdentifierFieldsSet(id *core.Identifier) error {
 	if id == nil {
 		return shared.GetMissingArgumentError(shared.ID)

--- a/pkg/manager/impl/validation/validation_test.go
+++ b/pkg/manager/impl/validation/validation_test.go
@@ -25,6 +25,17 @@ func TestValidateMaxLengthStringField(t *testing.T) {
 	assert.Equal(t, codes.InvalidArgument, err.(errors.FlyteAdminError).Code())
 }
 
+func TestValidateMaxMapLengthField(t *testing.T) {
+	labels := map[string]string{
+		"k1": "v1",
+		"k2": "v2",
+		"k3": "v3",
+	}
+	err := ValidateMaxMapLengthField(labels, "foo", 2)
+	assert.EqualError(t, err, "foo map cannot exceed 2 entries")
+	assert.Equal(t, codes.InvalidArgument, err.(errors.FlyteAdminError).Code())
+}
+
 func TestValidateIdentifier(t *testing.T) {
 	err := ValidateIdentifier(&core.Identifier{
 		ResourceType: core.ResourceType_TASK,

--- a/pkg/repositories/config/migrations.go
+++ b/pkg/repositories/config/migrations.go
@@ -199,7 +199,7 @@ var Migrations = []*gormigrate.Migration{
 			return tx.Exec("ALTER TABLE workflows ADD COLUMN IF NOT EXISTS state integer;").Error
 		},
 	},
-	// Modify the executions & node_executison table, if necessary
+	// Modify the executions & node_execution table, if necessary
 	{
 		ID: "2020-04-29-executions",
 		Migrate: func(tx *gorm.DB) error {


### PR DESCRIPTION
# TL;DR
Increase the validation done on `CreateProject` and `UpdateProject` in `project_manager.go`

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Increase the validation done on `CreateProject` and `UpdateProject` in `project_manager.go`:
* Validate `admin.Project` on `UpdateProject`
* Add length validation for `project-name`. It cannot contain more than 64 characters
* Add validation for number entries in `labels`. It cannot contain more than 16 labels



## Tracking Issue
https://github.com/lyft/flyte/issues/336

## Follow-up issue
_NA_
