### PR TITLE
Add Debug option to DB config

### DIFF
--- a/cmd/entrypoints/clusterresource.go
+++ b/cmd/entrypoints/clusterresource.go
@@ -41,6 +41,9 @@ var controllerRunCmd = &cobra.Command{
 		scope := promutils.NewScope(configuration.ApplicationConfiguration().GetTopLevelConfig().MetricsScope).NewSubScope("clusterresource")
 		dbConfigValues := configuration.ApplicationConfiguration().GetDbConfig()
 		dbConfig := repositoryConfig.DbConfig{
+			BaseConfig: repositoryConfig.BaseConfig{
+				IsDebug: dbConfigValues.Debug,
+			},
 			Host:         dbConfigValues.Host,
 			Port:         dbConfigValues.Port,
 			DbName:       dbConfigValues.DbName,
@@ -74,6 +77,9 @@ var controllerSyncCmd = &cobra.Command{
 		scope := promutils.NewScope(configuration.ApplicationConfiguration().GetTopLevelConfig().MetricsScope).NewSubScope("clusterresource")
 		dbConfigValues := configuration.ApplicationConfiguration().GetDbConfig()
 		dbConfig := repositoryConfig.DbConfig{
+			BaseConfig: repositoryConfig.BaseConfig{
+				IsDebug: dbConfigValues.Debug,
+			},
 			Host:         dbConfigValues.Host,
 			Port:         dbConfigValues.Port,
 			DbName:       dbConfigValues.DbName,

--- a/cmd/entrypoints/migrate.go
+++ b/cmd/entrypoints/migrate.go
@@ -34,6 +34,9 @@ var migrateCmd = &cobra.Command{
 		configuration := runtime.NewConfigurationProvider()
 		databaseConfig := configuration.ApplicationConfiguration().GetDbConfig()
 		postgresConfigProvider := config.NewPostgresConfigProvider(config.DbConfig{
+			BaseConfig: config.BaseConfig{
+				IsDebug: databaseConfig.Debug,
+			},
 			Host:         databaseConfig.Host,
 			Port:         databaseConfig.Port,
 			DbName:       databaseConfig.DbName,
@@ -68,6 +71,9 @@ var rollbackCmd = &cobra.Command{
 		configuration := runtime.NewConfigurationProvider()
 		databaseConfig := configuration.ApplicationConfiguration().GetDbConfig()
 		postgresConfigProvider := config.NewPostgresConfigProvider(config.DbConfig{
+			BaseConfig: config.BaseConfig{
+				IsDebug: databaseConfig.Debug,
+			},
 			Host:         databaseConfig.Host,
 			Port:         databaseConfig.Port,
 			DbName:       databaseConfig.DbName,
@@ -104,6 +110,9 @@ var seedProjectsCmd = &cobra.Command{
 		configuration := runtime.NewConfigurationProvider()
 		databaseConfig := configuration.ApplicationConfiguration().GetDbConfig()
 		postgresConfigProvider := config.NewPostgresConfigProvider(config.DbConfig{
+			BaseConfig: config.BaseConfig{
+				IsDebug: databaseConfig.Debug,
+			},
 			Host:         databaseConfig.Host,
 			Port:         databaseConfig.Port,
 			DbName:       databaseConfig.DbName,

--- a/pkg/repositories/config/postgres_test.go
+++ b/pkg/repositories/config/postgres_test.go
@@ -10,6 +10,9 @@ import (
 
 func TestConstructGormArgs(t *testing.T) {
 	postgresConfigProvider := NewPostgresConfigProvider(DbConfig{
+		BaseConfig: BaseConfig{
+			IsDebug: true,
+		},
 		Host:         "localhost",
 		Port:         5432,
 		DbName:       "postgres",
@@ -18,6 +21,7 @@ func TestConstructGormArgs(t *testing.T) {
 	}, mockScope.NewTestScope())
 
 	assert.Equal(t, "host=localhost port=5432 dbname=postgres user=postgres sslmode=disable", postgresConfigProvider.GetArgs())
+	assert.True(t, postgresConfigProvider.IsDebug())
 }
 
 func TestConstructGormArgsWithPassword(t *testing.T) {

--- a/pkg/rpc/adminservice/base.go
+++ b/pkg/rpc/adminservice/base.go
@@ -66,6 +66,9 @@ func NewAdminServer(kubeConfig, master string) *AdminService {
 
 	dbConfigValues := configuration.ApplicationConfiguration().GetDbConfig()
 	dbConfig := repositoryConfig.DbConfig{
+		BaseConfig: repositoryConfig.BaseConfig{
+			IsDebug: dbConfigValues.Debug,
+		},
 		Host:         dbConfigValues.Host,
 		Port:         dbConfigValues.Port,
 		DbName:       dbConfigValues.DbName,

--- a/pkg/runtime/application_config_provider.go
+++ b/pkg/runtime/application_config_provider.go
@@ -49,6 +49,7 @@ func (p *ApplicationConfigurationProvider) GetDbConfig() interfaces.DbConfig {
 		User:         dbConfigSection.User,
 		Password:     password,
 		ExtraOptions: dbConfigSection.ExtraOptions,
+		Debug:        dbConfigSection.Debug,
 	}
 }
 

--- a/pkg/runtime/interfaces/application_configuration.go
+++ b/pkg/runtime/interfaces/application_configuration.go
@@ -18,6 +18,8 @@ type DbConfigSection struct {
 	PasswordPath string `json:"passwordPath"`
 	// See http://gorm.io/docs/connecting_to_the_database.html for available options passed, in addition to the above.
 	ExtraOptions string `json:"options"`
+	// Whether or not to start the database connection with debug mode enabled.
+	Debug bool `json:"debug"`
 }
 
 // This represents a configuration used for initiating database connections much like DbConfigSection, however the
@@ -30,6 +32,7 @@ type DbConfig struct {
 	User         string `json:"username"`
 	Password     string `json:"password"`
 	ExtraOptions string `json:"options"`
+	Debug        bool   `json:"debug"`
 }
 
 // This configuration is the base configuration to start admin


### PR DESCRIPTION
# TL;DR
The postgres db debug mode in flyteadmin can now be set from the application config.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [x] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/lyft/flyte/issues/568

## Follow-up issue
_NA_
