### PR TITLE
Add single task execution create request validation

### DIFF
--- a/pkg/manager/impl/execution_manager_test.go
+++ b/pkg/manager/impl/execution_manager_test.go
@@ -3002,6 +3002,11 @@ func TestCreateSingleTaskExecution(t *testing.T) {
 				Version:      "12345",
 				ResourceType: core.ResourceType_TASK,
 			},
+			AuthRole: &admin.AuthRole{
+				Method: &admin.AuthRole_KubernetesServiceAccount{
+					KubernetesServiceAccount: "foo",
+				},
+			},
 		},
 		Inputs: &core.LiteralMap{
 			Literals: map[string]*core.Literal{

--- a/pkg/manager/impl/shared/constants.go
+++ b/pkg/manager/impl/shared/constants.go
@@ -14,10 +14,8 @@ const (
 	RuntimeVersion        = "runtime version"
 	Metadata              = "metadata"
 	TypedInterface        = "typed interface"
-	Container             = "container"
 	Image                 = "image"
 	Limit                 = "limit"
-	Offset                = "offset"
 	Filters               = "filters"
 	ExpectedInputs        = "expected_inputs"
 	FixedInputs           = "fixed_inputs"
@@ -34,7 +32,7 @@ const (
 	UserInputs            = "user_inputs"
 	Attributes            = "attributes"
 	MatchingAttributes    = "matching_attributes"
-	Resourcetype          = "resource_type"
 	// Parent of a node execution in the node executions table
 	ParentID = "parent_id"
+	AuthRole = "auth_role"
 )

--- a/pkg/manager/impl/validation/execution_validator.go
+++ b/pkg/manager/impl/validation/execution_validator.go
@@ -59,6 +59,11 @@ func ValidateExecutionRequest(ctx context.Context, request admin.ExecutionCreate
 			"Invalid reference entity resource type [%v], only [%+v] allowed",
 			request.Spec.LaunchPlan.ResourceType, acceptedReferenceLaunchTypes)
 	}
+	if request.Spec.LaunchPlan.ResourceType == core.ResourceType_TASK {
+		if err := validateLaunchSingleTaskExecutionReq(request); err != nil {
+			return err
+		}
+	}
 	if err := validateLiteralMap(request.Inputs, shared.Inputs); err != nil {
 		return err
 	}
@@ -154,6 +159,15 @@ func ValidateWorkflowExecutionIdentifier(identifier *core.WorkflowExecutionIdent
 	}
 	if err := ValidateEmptyStringField(identifier.Name, shared.Name); err != nil {
 		return err
+	}
+	return nil
+}
+
+// Because single task executions don't use launch plans, some parameters that are optional overrides for conventional
+// ExecutionCreateRequests are actually mandatory.
+func validateLaunchSingleTaskExecutionReq(request admin.ExecutionCreateRequest) error {
+	if request.Spec.AuthRole == nil {
+		return shared.GetMissingArgumentError(shared.AuthRole)
 	}
 	return nil
 }

--- a/pkg/manager/impl/validation/execution_validator.go
+++ b/pkg/manager/impl/validation/execution_validator.go
@@ -166,7 +166,7 @@ func ValidateWorkflowExecutionIdentifier(identifier *core.WorkflowExecutionIdent
 // Because single task executions don't use launch plans, some parameters that are optional overrides for conventional
 // ExecutionCreateRequests are actually mandatory.
 func validateLaunchSingleTaskExecutionReq(request admin.ExecutionCreateRequest) error {
-	if request.Spec.AuthRole == nil || request.Spec.AuthRole.GetMethod() == nil{
+	if request.Spec.AuthRole == nil || request.Spec.AuthRole.GetMethod() == nil {
 		return shared.GetMissingArgumentError(shared.AuthRole)
 	}
 	return nil

--- a/pkg/manager/impl/validation/execution_validator.go
+++ b/pkg/manager/impl/validation/execution_validator.go
@@ -166,7 +166,7 @@ func ValidateWorkflowExecutionIdentifier(identifier *core.WorkflowExecutionIdent
 // Because single task executions don't use launch plans, some parameters that are optional overrides for conventional
 // ExecutionCreateRequests are actually mandatory.
 func validateLaunchSingleTaskExecutionReq(request admin.ExecutionCreateRequest) error {
-	if request.Spec.AuthRole == nil {
+	if request.Spec.AuthRole == nil || request.Spec.AuthRole.GetMethod() == nil{
 		return shared.GetMissingArgumentError(shared.AuthRole)
 	}
 	return nil

--- a/pkg/manager/impl/validation/execution_validator_test.go
+++ b/pkg/manager/impl/validation/execution_validator_test.go
@@ -65,6 +65,22 @@ func TestValidateExecInvalidProjectAndDomain(t *testing.T) {
 	assert.EqualError(t, err, "failed to validate that project [project] and domain [domain] are registered, err: [foo]")
 }
 
+func TestValidateSingleTaskExecution(t *testing.T) {
+	request := testutils.GetExecutionRequest()
+	request.Spec.LaunchPlan.ResourceType = core.ResourceType_TASK
+
+	err := ValidateExecutionRequest(context.Background(), request, testutils.GetRepoWithDefaultProject(), execConfig)
+	assert.EqualError(t, err, "missing auth_role")
+
+	request.Spec.AuthRole = &admin.AuthRole{
+		Method: &admin.AuthRole_KubernetesServiceAccount{
+			KubernetesServiceAccount: "foo",
+		},
+	}
+	err = ValidateExecutionRequest(context.Background(), request, testutils.GetRepoWithDefaultProject(), execConfig)
+	assert.Nil(t, err)
+}
+
 func TestGetExecutionInputs(t *testing.T) {
 	executionRequest := testutils.GetExecutionRequest()
 	lpRequest := testutils.GetLaunchPlanRequest()


### PR DESCRIPTION
# TL;DR
Because single task executions don't use launch plans, some parameters that are optional overrides for conventional ExecutionCreateRequests are actually mandatory.

Note: the reference entity used to launch an execution is confusingly named LaunchPlan but accepts identifiers of task resouce_type.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [x] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description


## Tracking Issue
https://github.com/lyft/flyte/issues/567

## Follow-up issue
_NA_