### PR TITLE
Add filter and sort param when listing projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/jinzhu/gorm v1.9.12
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
 	github.com/lib/pq v1.3.0
-	github.com/lyft/flyteidl v0.18.10
+	github.com/lyft/flyteidl v0.18.11
 	github.com/lyft/flytepropeller v0.3.17
 	github.com/lyft/flytestdlib v0.3.9
 	github.com/magiconair/properties v1.8.1
@@ -58,5 +58,4 @@ replace (
 	k8s.io/api => github.com/lyft/api v0.0.0-20191031200350-b49a72c274e0
 	k8s.io/apimachinery => github.com/lyft/apimachinery v0.0.0-20191031200210-047e3ea32d7f
 	k8s.io/client-go => k8s.io/client-go v0.0.0-20191016111102-bec269661e48
-
 )

--- a/pkg/common/entity.go
+++ b/pkg/common/entity.go
@@ -16,6 +16,7 @@ const (
 	Workflow            = "w"
 	NamedEntity         = "nen"
 	NamedEntityMetadata = "nem"
+	Project             = "p"
 )
 
 // ResourceTypeToEntity maps a resource type to an entity suitable for use with Database filters

--- a/pkg/manager/impl/project_manager.go
+++ b/pkg/manager/impl/project_manager.go
@@ -57,7 +57,6 @@ func (m *ProjectManager) ListProjects(ctx context.Context, request admin.Project
 	spec := util.FilterSpec{
 		RequestFilters: request.Filters,
 	}
-
 	filters, err := util.GetDbFilters(spec, common.Project)
 	if err != nil {
 		return nil, err

--- a/pkg/manager/impl/project_manager.go
+++ b/pkg/manager/impl/project_manager.go
@@ -2,14 +2,20 @@ package impl
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/lyft/flyteadmin/pkg/common"
+	"github.com/lyft/flyteadmin/pkg/errors"
+	"github.com/lyft/flyteadmin/pkg/manager/impl/util"
 	"github.com/lyft/flyteadmin/pkg/manager/impl/validation"
 	"github.com/lyft/flyteadmin/pkg/manager/interfaces"
 	"github.com/lyft/flyteadmin/pkg/repositories"
+	repoInterfaces "github.com/lyft/flyteadmin/pkg/repositories/interfaces"
 	"github.com/lyft/flyteadmin/pkg/repositories/transformers"
 	runtimeInterfaces "github.com/lyft/flyteadmin/pkg/runtime/interfaces"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
+	"github.com/lyft/flytestdlib/logger"
+	"google.golang.org/grpc/codes"
 )
 
 type ProjectManager struct {
@@ -49,14 +55,57 @@ func (m *ProjectManager) getDomains() []*admin.Domain {
 }
 
 func (m *ProjectManager) ListProjects(ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error) {
-	projectModels, err := m.db.ProjectRepo().ListAll(ctx, alphabeticalSortParam)
+	if err := validation.ValidateLimit(request.Limit); err != nil {
+		logger.Debugf(ctx, "Invalid limit in request [%+v]: %v", request, err)
+		return nil, err
+	}
+
+	spec := util.FilterSpec{
+		RequestFilters: request.Filters,
+	}
+
+	filters, err := util.GetDbFilters(spec, common.Project)
 	if err != nil {
 		return nil, err
 	}
 
+	var sortParameter common.SortParameter
+	if request.SortBy != nil {
+		sortParameter, err = common.NewSortParameter(*request.SortBy)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		sortParameter = alphabeticalSortParam
+	}
+
+	offset, err := validation.ValidateToken(request.Token)
+	if err != nil {
+		return nil, errors.NewFlyteAdminErrorf(codes.InvalidArgument,
+			"invalid pagination token %s for ListProjects", request.Token)
+	}
+
+	// And finally, query the database
+	listProjectsInput := repoInterfaces.ListResourceInput{
+		Limit:         int(request.Limit),
+		Offset:        offset,
+		InlineFilters: filters,
+		SortParameter: sortParameter,
+	}
+	projectModels, err := m.db.ProjectRepo().List(ctx, listProjectsInput)
+	if err != nil {
+		return nil, err
+	}
 	projects := transformers.FromProjectModels(projectModels, m.getDomains())
+
+	var token string
+	if len(projects) == int(request.Limit) {
+		token = strconv.Itoa(offset + len(projects))
+	}
+
 	return &admin.Projects{
 		Projects: projects,
+		Token:    token,
 	}, nil
 }
 

--- a/pkg/manager/impl/project_manager.go
+++ b/pkg/manager/impl/project_manager.go
@@ -14,7 +14,6 @@ import (
 	"github.com/lyft/flyteadmin/pkg/repositories/transformers"
 	runtimeInterfaces "github.com/lyft/flyteadmin/pkg/runtime/interfaces"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
-	"github.com/lyft/flytestdlib/logger"
 	"google.golang.org/grpc/codes"
 )
 
@@ -55,11 +54,6 @@ func (m *ProjectManager) getDomains() []*admin.Domain {
 }
 
 func (m *ProjectManager) ListProjects(ctx context.Context, request admin.ProjectListRequest) (*admin.Projects, error) {
-	if err := validation.ValidateLimit(request.Limit); err != nil {
-		logger.Debugf(ctx, "Invalid limit in request [%+v]: %v", request, err)
-		return nil, err
-	}
-
 	spec := util.FilterSpec{
 		RequestFilters: request.Filters,
 	}

--- a/pkg/manager/impl/project_manager_test.go
+++ b/pkg/manager/impl/project_manager_test.go
@@ -5,10 +5,11 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/lyft/flyteadmin/pkg/common"
 	"github.com/lyft/flyteadmin/pkg/manager/impl/shared"
 
-	"github.com/lyft/flyteadmin/pkg/common"
 	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
+	"github.com/lyft/flyteadmin/pkg/repositories/interfaces"
 	repositoryMocks "github.com/lyft/flyteadmin/pkg/repositories/mocks"
 	"github.com/lyft/flyteadmin/pkg/repositories/models"
 	runtimeInterfaces "github.com/lyft/flyteadmin/pkg/runtime/interfaces"
@@ -45,10 +46,15 @@ func getMockApplicationConfigForProjectManagerTest() runtimeInterfaces.Applicati
 	return &mockApplicationConfig
 }
 
-func TestListProjects(t *testing.T) {
+func testListProjects(request admin.ProjectListRequest, token string, orderExpr string, queryExpr *common.GormQueryExpr, t *testing.T) {
 	repository := repositoryMocks.NewMockRepository()
 	repository.ProjectRepo().(*repositoryMocks.MockProjectRepo).ListProjectsFunction = func(
-		ctx context.Context, parameter common.SortParameter) ([]models.Project, error) {
+		ctx context.Context, input interfaces.ListResourceInput) ([]models.Project, error) {
+		if len(input.InlineFilters) != 0 {
+			q, _ := input.InlineFilters[0].GetGormQueryExpr()
+			assert.Equal(t, *queryExpr, q)
+		}
+		assert.Equal(t, orderExpr, input.SortParameter.GetGormOrderExpr())
 		activeState := int32(admin.Project_ACTIVE)
 		return []models.Project{
 			{
@@ -61,14 +67,44 @@ func TestListProjects(t *testing.T) {
 	}
 
 	projectManager := NewProjectManager(repository, mockProjectConfigProvider)
-	resp, err := projectManager.ListProjects(context.Background(), admin.ProjectListRequest{})
+	resp, err := projectManager.ListProjects(context.Background(), request)
 	assert.NoError(t, err)
 
 	assert.Len(t, resp.Projects, 1)
+	assert.Equal(t, token, resp.GetToken())
 	assert.Len(t, resp.Projects[0].Domains, 4)
 	for _, domain := range resp.Projects[0].Domains {
 		assert.Contains(t, testDomainsForProjManager, domain.Id)
 	}
+}
+
+func TestListProjects_NoFilters_LimitOne(t *testing.T) {
+	testListProjects(admin.ProjectListRequest{
+		Token: "1",
+		Limit: 1,
+	}, "2", "identifier asc", nil, t)
+}
+
+func TestListProjects_HighLimit_SortBy_Filter(t *testing.T) {
+	testListProjects(admin.ProjectListRequest{
+		Token:   "1",
+		Limit:   999,
+		Filters: "eq(project.name,foo)",
+		SortBy: &admin.Sort{
+			Key:       "name",
+			Direction: admin.Sort_DESCENDING,
+		},
+	}, "", "name desc", &common.GormQueryExpr{
+		Query: "name = ?",
+		Args:  "foo",
+	}, t)
+}
+
+func TestListProjects_NoLimit(t *testing.T) {
+	repository := repositoryMocks.NewMockRepository()
+	projectManager := NewProjectManager(repository, mockProjectConfigProvider)
+	_, err := projectManager.ListProjects(context.Background(), admin.ProjectListRequest{})
+	assert.NotNil(t, err)
 }
 
 func TestProjectManager_CreateProject(t *testing.T) {

--- a/pkg/manager/impl/project_manager_test.go
+++ b/pkg/manager/impl/project_manager_test.go
@@ -100,11 +100,8 @@ func TestListProjects_HighLimit_SortBy_Filter(t *testing.T) {
 	}, t)
 }
 
-func TestListProjects_NoLimit(t *testing.T) {
-	repository := repositoryMocks.NewMockRepository()
-	projectManager := NewProjectManager(repository, mockProjectConfigProvider)
-	_, err := projectManager.ListProjects(context.Background(), admin.ProjectListRequest{})
-	assert.NotNil(t, err)
+func TestListProjects_NoToken_NoLimit(t *testing.T) {
+	testListProjects(admin.ProjectListRequest{}, "", "identifier asc", nil, t)
 }
 
 func TestProjectManager_CreateProject(t *testing.T) {

--- a/pkg/manager/impl/util/filters.go
+++ b/pkg/manager/impl/util/filters.go
@@ -60,6 +60,7 @@ var filterFieldEntityPrefix = map[string]common.Entity{
 	"task_execution":        common.TaskExecution,
 	"entities":              common.NamedEntity,
 	"named_entity_metadata": common.NamedEntityMetadata,
+	"project":               common.Project,
 }
 
 func parseField(field string, primaryEntity common.Entity) (common.Entity, string) {
@@ -188,6 +189,7 @@ func getIdentifierFilters(entity common.Entity, spec FilterSpec) ([]common.Inlin
 
 func AddRequestFilters(requestFilters string, primaryEntity common.Entity, existingFilters []common.InlineFilter) (
 	[]common.InlineFilter, error) {
+
 	if requestFilters == "" {
 		return existingFilters, nil
 	}

--- a/pkg/repositories/gormimpl/project_repo.go
+++ b/pkg/repositories/gormimpl/project_repo.go
@@ -63,13 +63,12 @@ func (r *ProjectRepo) ListAll(ctx context.Context, sortParameter common.SortPara
 }
 
 func (r *ProjectRepo) List(ctx context.Context, input interfaces.ListResourceInput) ([]models.Project, error) {
-	// First validate input
-	if input.Limit == 0 {
-		return nil, errors.GetInvalidInputError(limit)
-	}
-
 	var projects []models.Project
-	tx := r.db.Limit(input.Limit).Offset(input.Offset)
+
+	tx := r.db.Offset(input.Offset)
+	if input.Limit != 0 {
+		tx = tx.Limit(input.Limit)
+	}
 
 	// Apply filters
 	// If no filter provided, default to filtering out archived projects

--- a/pkg/repositories/gormimpl/project_repo_test.go
+++ b/pkg/repositories/gormimpl/project_repo_test.go
@@ -7,6 +7,7 @@ import (
 	mocket "github.com/Selvatico/go-mocket"
 	"github.com/lyft/flyteadmin/pkg/common"
 	"github.com/lyft/flyteadmin/pkg/repositories/errors"
+	"github.com/lyft/flyteadmin/pkg/repositories/interfaces"
 	"github.com/lyft/flyteadmin/pkg/repositories/models"
 	"github.com/lyft/flyteidl/gen/pb-go/flyteidl/admin"
 	mockScope "github.com/lyft/flytestdlib/promutils"
@@ -57,7 +58,7 @@ func TestGetProject(t *testing.T) {
 	assert.Equal(t, int32(admin.Project_ACTIVE), *output.State)
 }
 
-func TestListProjects(t *testing.T) {
+func TestListAllProjects(t *testing.T) {
 	projectRepo := NewProjectRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
 	projects := make([]map[string]interface{}, 2)
 	fooProject := make(map[string]interface{})
@@ -94,6 +95,86 @@ func TestListProjects(t *testing.T) {
 	assert.Equal(t, "Bar", output[1].Name)
 	assert.Equal(t, "Bar description", output[1].Description)
 	assert.Equal(t, int32(admin.Project_ACTIVE), *output[1].State)
+}
+
+func TestListProjects(t *testing.T) {
+	projectRepo := NewProjectRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	projects := make([]map[string]interface{}, 1)
+	fooProject := make(map[string]interface{})
+	fooProject["identifier"] = "foo"
+	fooProject["name"] = "foo =)"
+	fooProject["description"] = "foo description"
+	fooProject["state"] = admin.Project_ACTIVE
+	projects[0] = fooProject
+
+	GlobalMock := mocket.Catcher.Reset()
+	GlobalMock.Logging = true
+	GlobalMock.NewMock().WithQuery(`SELECT * FROM "projects"  WHERE "projects"."deleted_at" IS NULL AND ((name = foo)) ORDER BY identifier asc LIMIT 1 OFFSET 0`).
+		WithReply(projects)
+
+	var alphabeticalSortParam, _ = common.NewSortParameter(admin.Sort{
+		Direction: admin.Sort_ASCENDING,
+		Key:       "identifier",
+	})
+	filter, err := common.NewSingleValueFilter(common.Project, common.Equal, "name", "foo")
+	assert.Nil(t, err)
+	output, err := projectRepo.List(context.Background(), interfaces.ListResourceInput{
+		Offset:        0,
+		Limit:         1,
+		InlineFilters: []common.InlineFilter{filter},
+		SortParameter: alphabeticalSortParam,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, output, 1)
+	assert.Equal(t, "foo", output[0].Identifier)
+	assert.Equal(t, "foo =)", output[0].Name)
+	assert.Equal(t, "foo description", output[0].Description)
+	assert.Equal(t, int32(admin.Project_ACTIVE), *output[0].State)
+}
+
+func TestListProjects_NoFilters(t *testing.T) {
+	projectRepo := NewProjectRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	projects := make([]map[string]interface{}, 1)
+	fooProject := make(map[string]interface{})
+	fooProject["identifier"] = "foo"
+	fooProject["name"] = "foo =)"
+	fooProject["description"] = "foo description"
+	fooProject["state"] = admin.Project_ACTIVE
+	projects[0] = fooProject
+
+	GlobalMock := mocket.Catcher.Reset()
+	GlobalMock.Logging = true
+	GlobalMock.NewMock().WithQuery(`SELECT * FROM "projects"  WHERE "projects"."deleted_at" IS NULL AND ((state != 1)) ORDER BY identifier asc LIMIT 1 OFFSET 0`).
+		WithReply(projects)
+
+	var alphabeticalSortParam, _ = common.NewSortParameter(admin.Sort{
+		Direction: admin.Sort_ASCENDING,
+		Key:       "identifier",
+	})
+	output, err := projectRepo.List(context.Background(), interfaces.ListResourceInput{
+		Offset:        0,
+		Limit:         1,
+		SortParameter: alphabeticalSortParam,
+	})
+	assert.Nil(t, err)
+	assert.Len(t, output, 1)
+	assert.Equal(t, "foo", output[0].Identifier)
+	assert.Equal(t, "foo =)", output[0].Name)
+	assert.Equal(t, "foo description", output[0].Description)
+	assert.Equal(t, int32(admin.Project_ACTIVE), *output[0].State)
+}
+
+func TestListProjects_NoLimit(t *testing.T) {
+	projectRepo := NewProjectRepo(GetDbForTest(t), errors.NewTestErrorTransformer(), mockScope.NewTestScope())
+	var alphabeticalSortParam, _ = common.NewSortParameter(admin.Sort{
+		Direction: admin.Sort_ASCENDING,
+		Key:       "identifier",
+	})
+	_, err := projectRepo.List(context.Background(), interfaces.ListResourceInput{
+		Limit:         0,
+		SortParameter: alphabeticalSortParam,
+	})
+	assert.NotNil(t, err)
 }
 
 func TestUpdateProject(t *testing.T) {

--- a/pkg/repositories/interfaces/project_repo.go
+++ b/pkg/repositories/interfaces/project_repo.go
@@ -14,6 +14,8 @@ type ProjectRepoInterface interface {
 	Get(ctx context.Context, projectID string) (models.Project, error)
 	// Lists unique projects registered as namespaces
 	ListAll(ctx context.Context, sortParameter common.SortParameter) ([]models.Project, error)
+	// Returns projects matching query parameters. A limit must be provided for the results page size.
+	List(ctx context.Context, input ListResourceInput) ([]models.Project, error)
 	// Given a project that exists in the DB and a partial set of fields to update
 	// as a second project (projectUpdate), updates the original project which already
 	// exists in the DB.

--- a/pkg/repositories/mocks/project_repo.go
+++ b/pkg/repositories/mocks/project_repo.go
@@ -11,14 +11,16 @@ import (
 
 type CreateProjectFunction func(ctx context.Context, project models.Project) error
 type GetProjectFunction func(ctx context.Context, projectID string) (models.Project, error)
-type ListProjectsFunction func(ctx context.Context, sortParameter common.SortParameter) ([]models.Project, error)
+type ListAllProjectsFunction func(ctx context.Context, sortParameter common.SortParameter) ([]models.Project, error)
+type ListProjectsFunction func(ctx context.Context, input interfaces.ListResourceInput) ([]models.Project, error)
 type UpdateProjectFunction func(ctx context.Context, projectUpdate models.Project) error
 
 type MockProjectRepo struct {
-	CreateFunction        CreateProjectFunction
-	GetFunction           GetProjectFunction
-	ListProjectsFunction  ListProjectsFunction
-	UpdateProjectFunction UpdateProjectFunction
+	CreateFunction          CreateProjectFunction
+	GetFunction             GetProjectFunction
+	ListProjectsFunction    ListProjectsFunction
+	ListAllProjectsFunction ListAllProjectsFunction
+	UpdateProjectFunction   UpdateProjectFunction
 }
 
 func (r *MockProjectRepo) Create(ctx context.Context, project models.Project) error {
@@ -40,8 +42,15 @@ func (r *MockProjectRepo) Get(ctx context.Context, projectID string) (models.Pro
 }
 
 func (r *MockProjectRepo) ListAll(ctx context.Context, sortParameter common.SortParameter) ([]models.Project, error) {
+	if r.ListAllProjectsFunction != nil {
+		return r.ListAllProjectsFunction(ctx, sortParameter)
+	}
+	return make([]models.Project, 0), nil
+}
+
+func (r *MockProjectRepo) List(ctx context.Context, input interfaces.ListResourceInput) ([]models.Project, error) {
 	if r.ListProjectsFunction != nil {
-		return r.ListProjectsFunction(ctx, sortParameter)
+		return r.ListProjectsFunction(ctx, input)
 	}
 	return make([]models.Project, 0), nil
 }


### PR DESCRIPTION
# TL;DR
Add filter and sort param when listing projects.

## Type
 - [ ] Bug Fix
 - [x] Feature
 - [ ] Plugin

## Are all requirements met?

 - [x] Code completed
 - [ ] Smoke tested
 - [x] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
This PR depends on https://github.com/lyft/flyteidl/pull/90

This revised API endpoint support filtering and sorting, as well as pagination. Everything is optional to keep backward compatibility.

* Offset defaults to `0` if no `token` provided
* Limit will not be set if not provided
* Filter defaults to `state != 1` to filter out archived projects
* Sort defaults to `identifier asc` if not provided
* The old list function is kept to be used by sync and we can of course switch to the new one

## Tracking Issue
https://github.com/lyft/flyte/issues/625

## Follow-up issue
_NA_
