### PR TITLE
Be more generous validating update project

### DIFF
--- a/pkg/manager/impl/project_manager_test.go
+++ b/pkg/manager/impl/project_manager_test.go
@@ -208,6 +208,7 @@ func TestProjectManager_UpdateProject(t *testing.T) {
 		assert.Equal(t, "project-id", projectUpdate.Identifier)
 		assert.Equal(t, "new-project-name", projectUpdate.Name)
 		assert.Equal(t, "new-project-description", projectUpdate.Description)
+		assert.Equal(t, int32(admin.Project_ACTIVE), *projectUpdate.State)
 		return nil
 	}
 	projectManager := NewProjectManager(mockRepository,
@@ -217,6 +218,7 @@ func TestProjectManager_UpdateProject(t *testing.T) {
 		Id:          "project-id",
 		Name:        "new-project-name",
 		Description: "new-project-description",
+		State:       admin.Project_ACTIVE,
 	})
 	assert.Nil(t, err)
 	assert.True(t, updateFuncCalled)

--- a/pkg/manager/impl/project_manager_test.go
+++ b/pkg/manager/impl/project_manager_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/lyft/flyteadmin/pkg/common"
-	"github.com/lyft/flyteadmin/pkg/manager/impl/shared"
 
 	"github.com/lyft/flyteadmin/pkg/manager/impl/testutils"
 	"github.com/lyft/flyteadmin/pkg/repositories/interfaces"
@@ -260,8 +259,8 @@ func TestProjectManager_UpdateProject_ErrorDueToInvalidProjectName(t *testing.T)
 		runtimeMocks.NewMockConfigurationProvider(
 			getMockApplicationConfigForProjectManagerTest(), nil, nil, nil, nil, nil))
 	_, err := projectManager.UpdateProject(context.Background(), admin.Project{
-		Id: "project-id",
-		// No project name
+		Id:   "project-id",
+		Name: "longnamelongnamelongnamelongnamelongnamelongnamelongnamelongnamel",
 	})
-	assert.Equal(t, shared.GetMissingArgumentError("project_name"), err)
+	assert.EqualError(t, err, "project_name cannot exceed 64 characters")
 }

--- a/pkg/manager/impl/validation/project_validator.go
+++ b/pkg/manager/impl/validation/project_validator.go
@@ -25,7 +25,11 @@ func ValidateProjectRegisterRequest(request admin.ProjectRegisterRequest) error 
 	if request.Project == nil {
 		return shared.GetMissingArgumentError(shared.Project)
 	}
-	return ValidateProject(*request.Project)
+	project := *request.Project
+	if err := ValidateEmptyStringField(project.Name, projectName); err != nil {
+		return err
+	}
+	return ValidateProject(project)
 }
 
 func ValidateProject(project admin.Project) error {
@@ -37,9 +41,6 @@ func ValidateProject(project admin.Project) error {
 	}
 	if errs := validation.IsDNS1123Label(project.Id); len(errs) > 0 {
 		return errors.NewFlyteAdminErrorf(codes.InvalidArgument, "invalid project id [%s]: %v", project.Id, errs)
-	}
-	if err := ValidateEmptyStringField(project.Name, projectName); err != nil {
-		return err
 	}
 	if err := ValidateMaxLengthStringField(project.Name, projectName, maxNameLength); err != nil {
 		return err

--- a/pkg/manager/impl/validation/project_validator_test.go
+++ b/pkg/manager/impl/validation/project_validator_test.go
@@ -145,8 +145,8 @@ func TestValidateProjectRegisterRequest(t *testing.T) {
 func TestValidateProject_ValidProject(t *testing.T) {
 	assert.Nil(t, ValidateProject(admin.Project{
 		Id:          "proj",
-		Name:        "proj",
 		Description: "An amazing description for this project",
+		State:       admin.Project_ARCHIVED,
 		Labels: &admin.Labels{
 			Values: map[string]string{
 				"foo": "bar",
@@ -181,12 +181,6 @@ func TestValidateProject(t *testing.T) {
 			expectedError: "invalid project id [%)(*&]: [a DNS-1123 label must consist of lower case alphanumeric " +
 				"characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or " +
 				"'123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')]",
-		},
-		{
-			project: admin.Project{
-				Id: "proj",
-			},
-			expectedError: "missing project_name",
 		},
 		{
 			project: admin.Project{


### PR DESCRIPTION
# TL;DR
https://github.com/lyft/flyteadmin/pull/132 added support for validating projects for both create and update. However when updating a project, it is reasonable to have some fields unset (empty string coming from gRPC). In case of archiving/activating a project, only project ID and state are required.

## Type
 - [x] Bug Fix
 - [ ] Feature
 - [ ] Plugin

## Are all requirements met?

 - [ ] Code completed
 - [ ] Smoke tested
 - [ ] Unit tests added
 - [ ] Code documentation added
 - [ ] Any pending items have an associated Issue

## Complete description
Executing for example ` flyte-cli archive-project -i -h <host:port> -p some-project`  can easily reproduce.

This PR skips validating empty string for `project.Name` when it is an update operation. Actually even for a create operation, it should be OK to leave `project.Name` unset, but to keep backward compatibility, this is still enforced.

## Tracking Issue
https://github.com/lyft/flyte/issues/336

## Follow-up issue
_NA_
